### PR TITLE
Fail dns_check step depending on nslookup output

### DIFF
--- a/roles/check_dns/tasks/main.yaml
+++ b/roles/check_dns/tasks/main.yaml
@@ -3,6 +3,9 @@
 - name: check internal cluster DNS resolution
   tags: check_dns,dns
   command: "nslookup {{ item }}"
+  register: command_result
+  # fail step if the output contains "server can't find"
+  failed_when: '"server can" in command_result.stdout'
   with_items:
     - "{{ env_bastion_name }}.{{ env_baseDomain }}"
     - "{{ env_bootstrap_name }}.{{ env_metadata_name }}.{{ env_baseDomain }}"
@@ -18,6 +21,9 @@
     
 - name: check external DNS resolution from DNS forwarder
   tags: check_dns,dns
+  register: command_result
+  # fail step if the output contains "server can't find"
+  failed_when: '"server can" in command_result.stdout'
   command: "nslookup {{ item }}"
   loop: 
     - www.google.com


### PR DESCRIPTION
Hi @jacobemery  @ftmiranda, 

I just saw #35 and noticed that the dns_check role doesn't fail based on the output. We need to examine the output because a host that does not exists is not considered an error in the `nslookup` world.


This PR adds the functionality to fail the step if the nslookup output contains
`server can't find`

In the code I only check for `server can` because I didn't find a way to escape the "`".. 
