### PR TITLE
Fix for the default storage pool usage. Use newly created storage pool.

### DIFF
--- a/roles/create_bootstrap/tasks/main.yaml
+++ b/roles/create_bootstrap/tasks/main.yaml
@@ -18,7 +18,7 @@
   command: |
     virt-install \
     --name {{ env.cluster.nodes.bootstrap.vm_name }} \
-    --disk pool=default,size={{ env.cluster.nodes.bootstrap.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.bootstrap.disk_size }}  \
     --ram {{ env.cluster.nodes.bootstrap.ram }} \
     --cpu host \
     --vcpus {{ env.cluster.nodes.bootstrap.vcpu }} \

--- a/roles/create_compute_nodes/tasks/main.yaml
+++ b/roles/create_compute_nodes/tasks/main.yaml
@@ -5,7 +5,7 @@
   command: |
     virt-install \
     --name {{env.cluster.nodes.compute.vm_name[i]}} \
-    --disk pool=default,size={{ env.cluster.nodes.compute.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
     --ram {{env.cluster.nodes.compute.ram}} \
     --cpu host \
     --vcpus {{env.cluster.nodes.compute.vcpu}} \
@@ -25,7 +25,7 @@
   command: |
     virt-install \
     --name {{env.cluster.nodes.infra.vm_name[i]}} \
-    --disk pool=default,size={{ env.cluster.nodes.infra.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }}  \
     --ram {{env.cluster.nodes.infra.ram}} \
     --cpu host \
     --vcpus {{env.cluster.nodes.infra.vcpu}} \
@@ -63,7 +63,7 @@
   command: |
     virt-install \
     --name {{compute_name[i]}} \
-    --disk pool=default,size={{ env.cluster.nodes.compute.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
     --ram {{env.cluster.nodes.compute.ram}} \
     --cpu host \
     --vcpus {{env.cluster.nodes.compute.vcpu}} \
@@ -83,7 +83,7 @@
   command: |
     virt-install \
     --name {{infra_name[i]}} \
-    --disk pool=default,size={{ env.cluster.nodes.infra.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }}  \
     --ram {{env.cluster.nodes.infra.ram}} \
     --cpu host \
     --vcpus {{env.cluster.nodes.infra.vcpu}} \

--- a/roles/create_control_nodes/tasks/main.yaml
+++ b/roles/create_control_nodes/tasks/main.yaml
@@ -5,7 +5,7 @@
   command: |
     virt-install \
     --name {{env.cluster.nodes.control.vm_name[i]}} \
-    --disk pool=default,size={{ env.cluster.nodes.control.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{env.cluster.nodes.control.ram}} \
     --cpu host \
     --vcpus {{env.cluster.nodes.control.vcpu}} \
@@ -26,7 +26,7 @@
   command: |
     virt-install \
     --name {{env.cluster.nodes.control.vm_name[0]}} \
-    --disk pool=default,size={{ env.cluster.nodes.control.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{env.cluster.nodes.control.ram}} \
     --cpu host \
     --vcpus {{env.cluster.nodes.control.vcpu}} \
@@ -43,7 +43,7 @@
   command: |
     virt-install \
     --name {{env.cluster.nodes.control.vm_name[1]}} \
-    --disk pool=default,size={{ env.cluster.nodes.control.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{env.cluster.nodes.control.ram}} \
     --cpu host \
     --vcpus {{env.cluster.nodes.control.vcpu}} \
@@ -60,7 +60,7 @@
   command: |
     virt-install \
     --name {{env.cluster.nodes.control.vm_name[2]}} \
-    --disk pool=default,size={{ env.cluster.nodes.control.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{env.cluster.nodes.control.ram}} \
     --cpu host \
     --vcpus {{env.cluster.nodes.control.vcpu}} \


### PR DESCRIPTION
During installation an own storage pool is being created named: {{ env.cluster.networking.metadata_name }}-vdisk
During installation of following nodes: bootstrap, control, compute and infra the default pool is being used rather than the newly created storage pool. 
This may lead to errors during execution of the playbook scripts because the file path of default storage pool may differ from storage path for newly created pool. 
This fix uses the newly created ({{ env.cluster.networking.metadata_name }}-vdisk) pool instead of the default pool.