### PR TITLE
Enable root user as installing user

### DIFF
--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -66,9 +66,9 @@
 **env.bastion.networking.name<br />server2** | <b>(Optional)</b> A second IPv4 address that resolves the bastion's hostname. | 192.168.10.201
 **env.bastion.networking.interface** | Name of the networking interface on the bastion from Linux's perspective. Most likely enc1. | enc1
 **env.bastion.networking.base_<br />domain** | Base domain that, when combined with the hostname, creates a fully-qualified<br /> domain name (FQDN) for the bastion? | ihost.com
-**env.bastion.access.user** | What would you like the admin's username to be on the bastion? | admin
-**env.bastion.access.pass** | The password to the bastion's admin user. | cH4ngeM3!
-**env.bastion.access.root_pass** | The root password for the bastion. | R0OtPa$s!
+**env.bastion.access.user** | What would you like the admin's username to be on the bastion?<br /> If root, make pass and root_pass vars the same. | admin
+**env.bastion.access.pass** | The password to the bastion's admin user. If using root, make<br /> pass and root_pass vars the same. | cH4ngeM3!
+**env.bastion.access.root_pass** | The root password for the bastion. If using root, make<br /> pass and root_pass vars the same. | R0OtPa$s!
 **env.bastion.options.dns** | Would you like the bastion to host the DNS information for the<br /> cluster? True or False. If false, resolution must come from<br /> elsewhere in your environment. Make sure to add IP addresses for<br /> KVM hosts, bastion, bootstrap, control, compute nodes, AND api,<br /> api-int and *.apps as described [here](https://docs.openshift.com/container-platform/4.8/installing/installing_bare_metal/installing-bare-metal-network-customizations.html) in section "User-provisioned<br /> DNS Requirements" Table 5. If True this will be done for you in<br /> the dns and check_dns roles. | True
 **env.bastion.options.load<br />balancer.on_bastion** | Would you like the bastion to host the load balancer (HAProxy) for the cluster?<br /> True or False (boolean).<br /> If false, this service must be provided elsewhere in your environment, and public and<br /> private IP of the load balancer must be<br /> provided in the following two variables. | True
 **env.bastion.options.load<br />balancer.public_ip** | (Only required if env.bastion.options.loadbalancer.on_bastion is True). The public IPv4<br /> address for your environment's loadbalancer. api, apps, *.apps must use this. | 192.168.10.50

--- a/playbooks/6_create_nodes.yaml
+++ b/playbooks/6_create_nodes.yaml
@@ -25,7 +25,7 @@
   roles:
     - create_control_nodes
 
-#Wait for bootstrap to connect control plane.
+#Wait for bootstrap to connect control plane (for users other than root).
 - hosts: bastion
   become: True
   environment:
@@ -34,7 +34,18 @@
   vars_files: 
     - "{{ inventory_dir }}/group_vars/all.yaml"
   roles:
-    - wait_for_bootstrap
+    - {role: wait_for_bootstrap, when: env.bastion.access.user != "root"}
+
+#Wait for bootstrap to connect to control plane (for root user)
+- hosts: bastion
+  become: True
+  environment:
+    KUBECONFIG: "/{{ env.bastion.access.user }}/.kube/config"
+  gather_facts: true
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/all.yaml"
+  roles:
+    - {role: wait_for_bootstrap, when: env.bastion.access.user == "root"}
 
 #Once bootstrapping is complete, tear down bootstrap.
 - hosts: kvm_host[-1]

--- a/playbooks/6_create_nodes.yaml
+++ b/playbooks/6_create_nodes.yaml
@@ -25,7 +25,7 @@
   roles:
     - create_control_nodes
 
-#Wait for bootstrap to connect control plane (for users other than root).
+#Wait for bootstrap to connect control plane (for non-root user).
 - hosts: bastion
   become: True
   environment:

--- a/playbooks/7_ocp_verification.yaml
+++ b/playbooks/7_ocp_verification.yaml
@@ -1,6 +1,6 @@
 ---
 
-#Complete OpenShift verification
+#Complete OpenShift verification (for none root users)
 - hosts: bastion
   become: True
   environment:
@@ -9,7 +9,21 @@
   vars_files: 
     - "{{ inventory_dir }}/group_vars/all.yaml"
   roles:
-    - approve_certs
-    - check_nodes
-    - wait_for_cluster_operators
-    - wait_for_install_complete
+    - {role: approve_certs, when: env.bastion.access.user != "root"}
+    - {role: check_nodes, when: env.bastion.access.user != "root"}
+    - {role: wait_for_cluster_operators, when: env.bastion.access.user != "root"}
+    - {role: wait_for_install_complete, when: env.bastion.access.user != "root"}
+
+#Complete OpenShift verification (for root user)
+- hosts: bastion
+  become: True
+  environment:
+    KUBECONFIG: "/{{ env.bastion.access.user }}/.kube/config"
+  gather_facts: true
+  vars_files: 
+    - "{{ inventory_dir }}/group_vars/all.yaml"
+  roles:
+    - {role: approve_certs, when: env.bastion.access.user == "root"}
+    - {role: check_nodes, when: env.bastion.access.user == "root"}
+    - {role: wait_for_cluster_operators, when: env.bastion.access.user == "root"}
+    - {role: wait_for_install_complete, when: env.bastion.access.user == "root"}

--- a/playbooks/7_ocp_verification.yaml
+++ b/playbooks/7_ocp_verification.yaml
@@ -1,6 +1,6 @@
 ---
 
-#Complete OpenShift verification (for none root users)
+#Complete OpenShift verification (for non-root users)
 - hosts: bastion
   become: True
   environment:

--- a/roles/get_ocp/tasks/main.yaml
+++ b/roles/get_ocp/tasks/main.yaml
@@ -156,7 +156,7 @@
     state: directory
     path: ~/.kube
 
-- name: Make kubeconfig admin user's default (none root).
+- name: Make kubeconfig admin user's default (for non-root user).
   tags: get_ocp, config
   copy:
     src: /root/ocpinst/auth/kubeconfig

--- a/roles/get_ocp/tasks/main.yaml
+++ b/roles/get_ocp/tasks/main.yaml
@@ -156,7 +156,7 @@
     state: directory
     path: ~/.kube
 
-- name: Make kubeconfig admin user's default.
+- name: Make kubeconfig admin user's default (none root).
   tags: get_ocp, config
   copy:
     src: /root/ocpinst/auth/kubeconfig
@@ -164,6 +164,17 @@
     owner: "{{ env.bastion.access.user }}"
     group: "{{ env.bastion.access.user }}"
     remote_src: yes
+  when: env.bastion.access.user != "root"
+
+- name: Make kubeconfig admin user's default (for root user).
+  tags: get_ocp, config
+  copy:
+    src: /root/ocpinst/auth/kubeconfig
+    dest: /{{ env.bastion.access.user }}/.kube/config
+    owner: "{{ env.bastion.access.user }}"
+    group: "{{ env.bastion.access.user }}"
+    remote_src: yes
+  when: env.bastion.access.user == "root"
 
 - name: Make kubeconfig root user's default.
   tags: get_ocp, config


### PR DESCRIPTION
Sometimes it is necessary (and very convenient) to work with the root user instead of using a specific user with sudo access.
Especially when used in a closed test environment in which various automation tests are being executed. 
This fix enables root user support for edge use cases.