### PR TITLE
Fix typo in tag

### DIFF
--- a/roles/create_bastion/tasks/main.yaml
+++ b/roles/create_bastion/tasks/main.yaml
@@ -58,7 +58,7 @@
     ins_dir: "{{ env.ftp.iso_mount_dir.split('/') }}"
 
 - name: Find FTP home for use in next step
-  tags: create_bastion, virt-isntall
+  tags: create_bastion, virt-install
   become: false
   command: echo $HOME
   register: ftp_home


### PR DESCRIPTION
Changed 'virt-isntall' to 'virt-install' on line 61  (Find FTP home for use in next step)

Signed-off-by: Barry Silliman silliman@us.ibm.com