### PR TITLE
feat: Add .editorconfig

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,19 @@
+---
+# .ansible-lint
+
+profile: null # min, basic, moderate, safety, shared, production
+
+# exclude_paths included in this file are parsed relative to this file's location
+# and not relative to the CWD of execution. CLI arguments passed to the --exclude
+# option are parsed relative to the CWD of execution.
+exclude_paths:
+  - .github/
+  - docs/
+# parseable: true
+# quiet: true
+# strict: true
+verbosity: 1
+
+skip_list:
+  - no-changed-when
+  - name[casing]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+[*.py]
+indent_size = 4
+
+[*.sh]
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2


### PR DESCRIPTION
Add .editorconfig to have consistent coding styles across editors and IDEs.

Signed-off-by: Klaus Smolin <SMOLIN@de.ibm.com>