### PR TITLE
feat: Add .ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,19 @@
+---
+# .ansible-lint
+
+profile: null # min, basic, moderate, safety, shared, production
+
+# exclude_paths included in this file are parsed relative to this file's location
+# and not relative to the CWD of execution. CLI arguments passed to the --exclude
+# option are parsed relative to the CWD of execution.
+exclude_paths:
+  - .github/
+  - docs/
+# parseable: true
+# quiet: true
+# strict: true
+verbosity: 1
+
+skip_list:
+  - no-changed-when
+  - name[casing]


### PR DESCRIPTION
Add ansible-lint config file. Ansible Lint is a command-line tool for linting playbooks, roles and collections aimed toward any Ansible users. Its main goal is to promote proven practices, patterns and behaviors while avoiding common pitfalls that can easily lead to bugs or make code harder to maintain.

Signed-off-by: Klaus Smolin <SMOLIN@de.ibm.com>