### PR TITLE
feat: Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+[*.py]
+indent_size = 4
+
+[*.sh]
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2


### PR DESCRIPTION
Add .editorconfig to have consistent coding styles across editors and IDEs.

Signed-off-by: Klaus Smolin <SMOLIN@de.ibm.com>