### PR TITLE
feat: Untrack all.yaml file in git

### DIFF
--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -1,7 +1,7 @@
 # Step 2: Set Variables (group_vars)
 ## Overview
-* In a text editor of your choice, open the [environment variables file](https://github.com/IBM/Ansible-OpenShift-Provisioning/blob/main/inventories/default/group_vars/all.yaml).
-* This is the master variables file and you will likely reference it many times throughout the process. The default inventory can be found at [inventories/default/group_vars/all.yaml](https://github.com/IBM/Ansible-OpenShift-Provisioning/blob/main/inventories/default/group_vars/all.yaml).
+* In a text editor of your choice, open the template of the [environment variables file](https://github.com/IBM/Ansible-OpenShift-Provisioning/blob/main/inventories/default/group_vars/all.yaml.template). Make a copy of it called all.yaml and paste it into the same directory with its template.
+* all.yaml is your master variables file and you will likely reference it many times throughout the process. The default inventory can be found at [inventories/default](https://github.com/IBM/Ansible-OpenShift-Provisioning/blob/main/inventories/default).
 * The variables mark with an `X` are required to be filled in. Many values are pre-filled or are optional. Optional values are commented out; in order to use them, remove the `#` and fill them in.
 * This is the most important step in the process. Take the time to make sure everything here is correct.
 * <u>Note on YAML syntax</u>: Only the lowest value in each hierarchicy needs to be filled in. For example, at the top of the variables file env and z don't need to be filled in, but the cpc_name does. There are X's where input is required to help you with this.

--- a/inventories/default/group_vars/.gitignore
+++ b/inventories/default/group_vars/.gitignore
@@ -1,0 +1,1 @@
+all.yaml

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -1,4 +1,4 @@
-# Copy this file to 'all.yaml' and add your required values there !
+# Copy this file to 'all.yaml' in the same folder and add your required values there !
 #
 # For a comprehensive description of each variable, please see documentation here:
 # https://ibm.github.io/Ansible-OpenShift-Provisioning/set-variables-group-vars/ 

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -1,3 +1,5 @@
+# Copy this file to 'all.yaml' and add your required values there !
+#
 # For a comprehensive description of each variable, please see documentation here:
 # https://ibm.github.io/Ansible-OpenShift-Provisioning/set-variables-group-vars/ 
 


### PR DESCRIPTION
The inventory file 'all.yaml' is part of the current git structure. This file is always modifed to execute Ansible-OpenShift-Provisioning and therefore it will be tracked in your git branch as modifed. But, it will not be commited, because it contains credentials !

This patch renames the original file to a template filename. The user needs to create a local 'all.yaml' copy.

Signed-off-by: Klaus Smolin <SMOLIN@de.ibm.com>