### PR TITLE
fix(ssh): Some minor fixes

### DIFF
--- a/roles/ssh_copy_id/tasks/main.yaml
+++ b/roles/ssh_copy_id/tasks/main.yaml
@@ -2,7 +2,7 @@
 
 - name: Load in variables
   tags: ssh_copy_id, ssh
-  include_vars: "{{inventory_dir}}/group_vars/all.yaml"
+  include_vars: "{{ inventory_dir }}/group_vars/all.yaml"
 
 - name: Get ansible public key for check in next task
   tags: ssh_copy_id, ssh
@@ -12,7 +12,7 @@
 - name: Print Ansible public key
   tags: ssh_copy_id, ssh
   debug:
-    msg: "{{ ans_pub_key }}"
+    var: ans_pub_key
 
 - name: Delete SSH key from known hosts if it already exists for idempotency
   tags: ssh_copy_id, ssh
@@ -33,7 +33,7 @@
   command: "expect {{ role_path }}/files/ssh-copy-id-expect-pass.exp"
   register: ssh_copy
 
-- name: Print results of copying ssh id to remote host.
+- name: Print results of copying ssh id to remote host
   tags: ssh_copy_id, ssh
   debug:
     var: ssh_copy

--- a/roles/ssh_copy_id/templates/ssh-copy-id.exp.j2
+++ b/roles/ssh_copy_id/templates/ssh-copy-id.exp.j2
@@ -9,10 +9,10 @@ if {$force_conservative} {
 	}
 }
 
-set timeout -1
-spawn ssh-copy-id -o StrictHostKeyChecking=no -i {{path_to_key_pair}} {{ ssh_target[1] }}@{{ ssh_target[0] }}
+set timeout 20
+spawn ssh-copy-id -f -o StrictHostKeyChecking=no -i {{ path_to_key_pair }} {{ ssh_target[1] }}@{{ ssh_target[0] }}
 expect {
-	"*assword: " {
+	"password: " {
 		send -- "{{ ssh_target[2] }}\r"
 		expect eof
 	}

--- a/roles/ssh_key_gen/tasks/main.yaml
+++ b/roles/ssh_key_gen/tasks/main.yaml
@@ -32,6 +32,6 @@
 - name: Save path to key pair for use in ssh-copy-id role
   tags: ssh_key_gen, ssh
   lineinfile:
-    line: "path_to_key_pair: {{ssh_key_creation.filename}}.pub"
-    path: "{{inventory_dir}}/group_vars/all.yaml"
-    insertafter: EOF #end of file
+    search_string: "path_to_key_pair:"
+    line: "path_to_key_pair: {{ ssh_key_creation.filename }}.pub"
+    path: "{{ inventory_dir }}/group_vars/all.yaml"

--- a/roles/ssh_ocp_key_gen/tasks/main.yaml
+++ b/roles/ssh_ocp_key_gen/tasks/main.yaml
@@ -23,7 +23,7 @@
     owner: root
     passphrase: ""
     comment: "{{ env.ocp_ssh_key_comment }}"
-    regenerate: always
+    regenerate: full_idempotence
   register: ssh_ocp
 
 - name: Print results of SSH key generation
@@ -41,7 +41,7 @@
 
 - name: Set SSH key ownership
   tags: ssh_ocp_key_gen
-  command: chown root:root /root/.ssh/{{item}}
+  command: chown root:root /root/.ssh/{{ item }}
   loop:
     - id_rsa
     - id_rsa.pub


### PR DESCRIPTION
fix: Set timeout for ssh-copy-id, do not wait forever
fix: Force ssh-copy-id, to avoid issues if the key already exists
fix: Duplicate creation of 'path_to_key_pair' variable in 'all.yaml' file

Signed-off-by: Klaus Smolin <smolin@de.ibm.com>