### PR TITLE
fix(bootstrap): Deletion of existing VM image

### DIFF
--- a/playbooks/5_setup_bastion.yaml
+++ b/playbooks/5_setup_bastion.yaml
@@ -1,32 +1,32 @@
 ---
 
-#Copy SSH key to access bastion
-- hosts: localhost
+- name: 5 setup bastion - copy SSH key to access bastion
+  hosts: workstation
   tags: ssh, ssh_copy_id, section_1
   connection: local
   become: false
   gather_facts: false
-  vars_files: 
+  vars_files:
     - "{{ inventory_dir }}/group_vars/all.yaml"
-  vars: 
-    ssh_target: ["{{ env.bastion.networking.ip }}","{{ env.bastion.access.user }}","{{ env.bastion.access.pass }}"]
+  vars:
+    ssh_target: ["{{ env.bastion.networking.ip }}", "{{ env.bastion.access.user }}", "{{ env.bastion.access.pass }}"]
   roles:
     - ssh_copy_id
 
-#Configure bastion node with essential services
-- hosts: bastion
+- name: 5 setup bastion - configure bastion node with essential services
+  hosts: bastion
   tags: services, section_2
   become: True
   vars:
     packages: "{{ env.pkgs.bastion }}"
-  vars_files: 
+  vars_files:
     - "{{ inventory_dir }}/group_vars/all.yaml"
   roles:
-    - {role: attach_subscription, when: env.redhat.username is defined and env.redhat.password is defined}
+    - { role: attach_subscription, when: env.redhat.username is defined and env.redhat.password is defined }
     - install_packages
     - ssh_ocp_key_gen
     - set_firewall
-    - {role: dns, when: env.bastion.options.dns }
+    - { role: dns, when: env.bastion.options.dns }
     - check_dns
     - { role: haproxy, when: env.bastion.options.loadbalancer.on_bastion }
     - httpd
@@ -41,12 +41,12 @@
     - { role: robertdebock.epel, tags: openvpn, when: env.z.high_availability == True }
     - { role: robertdebock.openvpn, tags: openvpn, when: env.z.high_availability == True }
 
-- hosts: localhost
+- hosts: workstation
   tags: services, section_2, openvpn
   become: false
   gather_facts: false
   tasks:
-    - name: Create landing directories on controller for certificates and keys.
+    - name: Create landing directories on workstation for certificates and keys.
       tags: openvpn
       file:
         state: directory
@@ -86,7 +86,7 @@
         - issued
         - private
 
-    - name: Copy certificates and keys from controller to KVM hosts.
+    - name: Copy certificates and keys from workstation to KVM hosts.
       tags: openvpn
       copy:
         src: tmp/{{ item }}
@@ -101,13 +101,13 @@
   roles:
     - { role: robertdebock.epel, tags: openvpn, when: env.z.high_availability == True }
     - { role: robertdebock.openvpn, tags: openvpn, when: env.z.high_availability == True }
-  
-- hosts: localhost
+
+- hosts: workstation
   tags: services, section_2, openvpn
   become: false
   gather_facts: false
   tasks:
-    - name: Clean up tmp directories on controller for certificates and keys.
+    - name: Clean up tmp directories on workstation for certificates and keys.
       tags: openvpn
       file:
         state: absent
@@ -116,7 +116,7 @@
 - hosts: bastion
   tags: get_ocp, section_3
   become: True
-  vars_files: 
+  vars_files:
     - "{{ inventory_dir }}/group_vars/all.yaml"
   roles:
     - get_ocp

--- a/playbooks/6_create_nodes.yaml
+++ b/playbooks/6_create_nodes.yaml
@@ -1,10 +1,11 @@
 ---
 
-#Prepare and then create the temporary bootstrap node and the control nodes.
-- hosts: kvm_host
+# Prepare and then create the temporary bootstrap node and the control nodes
+- name: 6 create nodes - prepare KVM guests
+  hosts: kvm_host
   become: true
   gather_facts: false
-  vars_files: 
+  vars_files:
     - "{{ inventory_dir }}/group_vars/all.yaml"
   roles:
     - prep_kvm_guests
@@ -12,7 +13,7 @@
 - hosts: kvm_host[-1]
   become: true
   gather_facts: false
-  vars_files: 
+  vars_files:
     - "{{ inventory_dir }}/group_vars/all.yaml"
   roles:
     - create_bootstrap
@@ -20,24 +21,24 @@
 - hosts: kvm_host
   become: true
   gather_facts: false
-  vars_files: 
+  vars_files:
     - "{{ inventory_dir }}/group_vars/all.yaml"
   roles:
     - create_control_nodes
 
-#Wait for bootstrap to connect control plane (for non-root user).
-- hosts: bastion
+- name: 6 create nodes - wait for bootstrap to connect control plane (for non-root user)
+  hosts: bastion
   become: True
   environment:
     KUBECONFIG: "/home/{{ env.bastion.access.user }}/.kube/config"
   gather_facts: true
-  vars_files: 
+  vars_files:
     - "{{ inventory_dir }}/group_vars/all.yaml"
   roles:
     - {role: wait_for_bootstrap, when: env.bastion.access.user != "root"}
 
-#Wait for bootstrap to connect to control plane (for root user)
-- hosts: bastion
+- name: 6 create nodes - wait for bootstrap to connect to control plane (for root user)
+  hosts: bastion
   become: True
   environment:
     KUBECONFIG: "/{{ env.bastion.access.user }}/.kube/config"
@@ -47,14 +48,14 @@
   roles:
     - {role: wait_for_bootstrap, when: env.bastion.access.user == "root"}
 
-#Once bootstrapping is complete, tear down bootstrap.
-- hosts: kvm_host[-1]
+- name: 6 create nodes - once bootstrapping is complete, tear down bootstrap.
+  hosts: kvm_host[-1]
   tags: create_nodes, teardown_bootstrap
   become: True
   gather_facts: False
-  vars_files: 
+  vars_files:
     - "{{ inventory_dir }}/group_vars/all.yaml"
-  tasks: 
+  tasks:
     - name: Destroy bootstrap. Expect ignored errors if bootstrap is already destroyed.
       tags: create_nodes, teardown_bootstrap
       community.libvirt.virt:
@@ -73,15 +74,15 @@
       tags: create_nodes, teardown_bootstrap
       become: true
       file:
-        path: "/var/lib/libvirt/images/{{env.cluster.nodes.bootstrap.vm_name}}-bootstrap.qcow2"
+        path: "/var/lib/libvirt/images/{{ env.cluster.nodes.bootstrap.vm_name }}.qcow2"
         state: absent
 
-#Once bootstrapping is complete, create compute nodes.
-- hosts: kvm_host
+- name: 6 create nodes - once bootstrapping is complete, create compute nodes.
+  hosts: kvm_host
   tags: create_compute_nodes
   become: true
   gather_facts: false
-  vars_files: 
+  vars_files:
     - "{{ inventory_dir }}/group_vars/all.yaml"
   roles:
     - create_compute_nodes

--- a/roles/create_bootstrap/tasks/main.yaml
+++ b/roles/create_bootstrap/tasks/main.yaml
@@ -1,21 +1,12 @@
 ---
 
-- name: Check if bootstrap already exists
-  tags: create_bootstrap
-  community.libvirt.virt:
-    name: "{{ env.cluster.nodes.bootstrap.vm_name }}"
-    command: status
-  register: bootstrap_check
-  ignore_errors: true
-
-- name: Print status of bootstrap
-  tags: create_bootstrap
-  debug: 
-    var: bootstrap_check.msg
-
+# We create always a new bootstrap VM
 - name: Start bootstrap installation
   tags: create_bootstrap
-  command: |
+  ansible.builtin.shell: |
+    set -o pipefail
+    virsh destroy {{ env.cluster.nodes.bootstrap.vm_name }} || true
+    virsh undefine {{ env.cluster.nodes.bootstrap.vm_name }} --remove-all-storage || true
     virt-install \
     --name {{ env.cluster.nodes.bootstrap.vm_name }} \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.bootstrap.disk_size }}  \
@@ -24,11 +15,14 @@
     --vcpus {{ env.cluster.nodes.bootstrap.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-s390x,initrd=rhcos-live-initramfs.s390x.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs.s390x.img ip={{env.cluster.nodes.bootstrap.ip}}::{{networking.gateway}}:{{networking.subnetmask}}:{{env.cluster.nodes.bootstrap.hostname}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/bootstrap.ign" \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda \
+    coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/rhcos-live-rootfs.s390x.img \
+    ip={{ env.cluster.nodes.bootstrap.ip }}::{{ networking.gateway }}:{{ networking.subnetmask }}:{{ env.cluster.nodes.bootstrap.hostname }}::none:1500 \
+    nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} \
+    coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/bootstrap.ign" \
     --graphics none \
     --wait=-1 \
-    --noautoconsole 
-  when: bootstrap_check.failed == true
+    --noautoconsole
 
 - name: Set bootstrap qcow2 permissions
   become: true


### PR DESCRIPTION
Delete correct bootstrap qcow2 image.

The bootstrop VM is deleted after creation of control nodes. But, in case of an issue, the VM is not deleted. New config bootstrap changes are ignored, because the existing old bootstrap VM is used on the next executions until the VM is manually deleted.
We are now deleting and creating the bootstrap VM on each test run, to solve the above issue.

Signed-off-by: Klaus Smolin <smolin@de.ibm.com>