### PR TITLE
feat: Add delete_nodes role

### DIFF
--- a/playbooks/6_create_nodes.yaml
+++ b/playbooks/6_create_nodes.yaml
@@ -8,6 +8,8 @@
     - "{{ inventory_dir }}/group_vars/all.yaml"
   roles:
     - prep_kvm_guests
+    # Delete control, compute and infra nodes, if exists
+    - delete_nodes
 
 - hosts: kvm_host[-1]
   become: true

--- a/playbooks/reinstall_nodes.yaml
+++ b/playbooks/reinstall_nodes.yaml
@@ -1,0 +1,5 @@
+# Use this if you want to re-install nodes with a new OCP version
+---
+
+- import_playbook: 6_create_nodes.yaml
+- import_playbook: 7_ocp_verification.yaml

--- a/roles/delete_nodes/tasks/main.yaml
+++ b/roles/delete_nodes/tasks/main.yaml
@@ -1,0 +1,22 @@
+---
+
+- name: Delete control, compute and infra nodes, if exists
+  tags: delete_nodes
+  ansible.builtin.shell: |
+    set -o pipefail
+    virsh destroy {{ item }} || true
+    virsh undefine {{ item }} --remove-all-storage || true
+  loop: "{{ env.cluster.nodes.control.vm_name + env.cluster.nodes.compute.vm_name \
+    if env.cluster.nodes.infra.vm_name is not defined \
+    else env.cluster.nodes.control.vm_name + env.cluster.nodes.compute.vm_name + env.cluster.nodes.infra.vm_name }}"
+
+- name: Get and print virsh list
+  tags: delete_nodes
+  block:
+    - name: Get virsh list
+      ansible.builtin.command: virsh list
+      register: cmd_virsh_list
+
+    - name: Print virsh list
+      ansible.builtin.debug:
+        var: cmd_virsh_list.stdout_lines


### PR DESCRIPTION
In case you want to re-install the cluster, because of an install problem or of a new OCP version, then you can just execute playbooks:
 * 6_create_nodes.yaml
 * 7_ocp_verification.yaml

In order to have a clean setup on each run, we delete all existing control, compute and infra nodes. Bastion node will not be deleted.

Signed-off-by: Klaus Smolin <smolin@de.ibm.com>