### PR TITLE
Revert pastion ns patch

### DIFF
--- a/roles/create_bastion/tasks/main.yaml
+++ b/roles/create_bastion/tasks/main.yaml
@@ -69,7 +69,7 @@
     --network network={{ env.bridge_name }} \
     --graphics=none \
     --noautoconsole --wait=-1 \
-    --initrd-inject "/{{ kvm_host_home.stdout }}/{{ env.ftp.cfgs_dir }}/{{ env.bastion.networking.hostname }}/bastion-ks.cfg \
+    --initrd-inject "/{{ kvm_host_home.stdout }}/{{ env.ftp.cfgs_dir }}/{{ env.bastion.networking.hostname }}/bastion-ks.cfg" \
     nameserver={{env.bastion.networking.nameserver1}} {{ ('nameserver=' + env.bastion.networking.nameserver2) if env.bastion.networking.nameserver2 is defined else '' }} \
     console=ttysclp0"
 

--- a/roles/create_bastion/tasks/main.yaml
+++ b/roles/create_bastion/tasks/main.yaml
@@ -70,8 +70,8 @@
     --graphics=none \
     --noautoconsole --wait=-1 \
     --initrd-inject "/{{ kvm_host_home.stdout }}/{{ env.ftp.cfgs_dir }}/{{ env.bastion.networking.hostname }}/bastion-ks.cfg" \
-    nameserver={{env.bastion.networking.nameserver1}} {{ ('nameserver=' + env.bastion.networking.nameserver2) if env.bastion.networking.nameserver2 is defined else '' }} \
-    console=ttysclp0"
+    --extra-args "inst.ks=file:/bastion-ks.cfg ip={{ env.bastion.networking.ip }}::{{ env.bastion.networking.gateway }}\
+    :{{ env.bastion.networking.subnetmask }}:{{ env.bastion.networking.hostname }}:enc1:none console=ttysclp0"
 
 - name: Waiting 1 minute for automated bastion installation and configuration to complete
   tags: create_bastion, virt-install

--- a/roles/create_bastion/templates/bastion-ks.cfg.j2
+++ b/roles/create_bastion/templates/bastion-ks.cfg.j2
@@ -33,7 +33,7 @@ timezone {{ env.timezone }}
 eula --agreed
 
 # Network information (will fill in during create_bastion role)
-network --bootproto=static --device={{ env.bastion.networking.interface }} --ip={{ env.bastion.networking.ip }} --gateway={{env.bastion.networking.gateway}}  --netmask={{env.bastion.networking.subnetmask}}  --noipv6 --nameserver={{env.bastion.networking.nameserver1}}{{ (',' + env.bastion.networking.nameserver2) if env.bastion.networking.nameserver2 is defined else '' }} --activate
+network --bootproto=static --device={{ env.bastion.networking.interface }} --ip={{ env.bastion.networking.ip }} --gateway={{env.bastion.networking.gateway}}  --netmask={{env.bastion.networking.subnetmask}}  --noipv6 --nameserver={{env.bastion.networking.nameserver1}} {{ ('--nameserver=' + env.bastion.networking.nameserver2) if env.bastion.networking.nameserver2 is defined else '' }} --activate
 network --hostname={{ env.bastion.networking.hostname }}.{{ env.cluster.networking.base_domain }}
 
 # Firewall and SELinux


### PR DESCRIPTION
The required parameter "--extra-args" was removed in the virt-install command.
This is causing the VM creation to fail.
Therefore removing the patch until a new patch is available.