### PR TITLE
fix: Add api.<metadata_name>.<base_domain> to /etc/hosts

### DIFF
--- a/roles/wait_for_install_complete/tasks/main.yaml
+++ b/roles/wait_for_install_complete/tasks/main.yaml
@@ -1,38 +1,33 @@
 ---
 
-- name: Wait for OpenShift install to complete
+- name: Almost there! Add host info to /etc/hosts so you can login to the cluster via web browser. Ansible Controller sudo password required
   tags: wait_for_install_complete
-  shell: openshift-install wait-for install-complete --dir /root/ocpinst
-  register: wait_install_complete
-  until: ("Install complete!" in wait_install_complete.stderr)
-  retries: 120
-  delay: 30
-
-- name: Almost there! Add host info to /etc/hosts so you can login to the cluster via web browser. Ansible Controller sudo password required.
-  tags: wait_for_install_complete
-  become: True
+  become: true
   lineinfile:
     path: /etc/hosts
     line: "{{ item }}"
   with_items:
     - "{{ env.bastion.networking.ip }} oauth-openshift.apps.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}"
     - "{{ env.bastion.networking.ip }} console-openshift-console.apps.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}"
+    - "{{ env.bastion.networking.ip }} api.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}"
   delegate_to: 127.0.0.1
 
 - name: Get OCP URL
   tags: wait_for_install_complete
   set_fact:
-    ocp_url: https://console-openshift-console.apps.{{env.cluster.networking.metadata_name}}.{{env.cluster.networking.base_domain}}
+    ocp_url: https://console-openshift-console.apps.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}
 
 - name: Get OCP temporary password
   tags: wait_for_install_complete
   command: "cat /root/ocpinst/auth/kubeadmin-password"
   register: ocp_passwd
+  changed_when: false
 
 - name: Congratulations! OpenShift installation complete. Use the information below for first-time login via web browser.
   tags: wait_for_install_complete
   command: "echo {{ item }}"
   loop:
-    - " URL: {{ocp_url}} "
+    - " URL: {{ ocp_url }} "
     - " Username: kubeadmin "
-    - " Password: {{ocp_passwd.stdout}} "
+    - " Password: {{ ocp_passwd.stdout }} "
+  changed_when: false


### PR DESCRIPTION
Add api.{{ metadata_name }}.{{ base_domain }} to /etc/hosts Remove 'wait for install check'. Because install is already completed at this stage

Signed-off-by: Klaus Smolin <smolin@de.ibm.com>