### PR TITLE
fix: Disable /etc/resolv.conf updates by NetworkManager

### DIFF
--- a/roles/dns/files/90-dns-none.conf
+++ b/roles/dns/files/90-dns-none.conf
@@ -1,0 +1,2 @@
+[main]
+dns=none

--- a/roles/dns/tasks/main.yaml
+++ b/roles/dns/tasks/main.yaml
@@ -1,5 +1,4 @@
 ---
-
 - name: Enable named
   tags: dns
   ansible.builtin.systemd:
@@ -14,59 +13,59 @@
 
 - name: Split IP addresses for use in templates
   tags: dns
-  set_fact:
+  ansible.builtin.set_fact:
     bastion_split_ip: "{{ env.bastion.networking.ip.split('.') }}"
     bootstrap_split_ip: "{{ env.cluster.nodes.bootstrap.ip.split('.') }}"
 
 - name: Template named.conf file to bastion
   tags: dns
-  template:
+  ansible.builtin.template:
     src: dns-named.conf.j2
     dest: /etc/named.conf
     owner: root
     group: root
-    mode: '0755'
+    mode: "0644"
     backup: yes
 
 - name: Template DNS forwarding file to bastion
   tags: dns
-  template:
+  ansible.builtin.template:
     src: dns.db.j2
-    dest: /var/named/{{env.cluster.networking.metadata_name}}.db
+    dest: /var/named/{{ env.cluster.networking.metadata_name }}.db
     owner: named
     group: named
-    mode: '0755'
+    mode: "0644"
     backup: yes
 
 - name: Add control nodes to DNS forwarding file on bastion
   tags: dns
-  lineinfile:
-    path: /var/named/{{env.cluster.networking.metadata_name}}.db
+  ansible.builtin.lineinfile:
+    path: /var/named/{{ env.cluster.networking.metadata_name }}.db
     insertafter: "entries for the control nodes"
     line: "{{ env.cluster.nodes.control.hostname[i] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}. IN A {{ env.cluster.nodes.control.ip[i] }}"
-  with_sequence: start=0 end={{(env.cluster.nodes.control.hostname | length) - 1}} stride=1
+  with_sequence: start=0 end={{ (env.cluster.nodes.control.hostname | length) - 1 }} stride=1
   loop_control:
     extended: yes
     index_var: i
 
 - name: Add compute nodes to DNS forwarding file on bastion
   tags: dns
-  lineinfile:
-    path: /var/named/{{env.cluster.networking.metadata_name}}.db
+  ansible.builtin.lineinfile:
+    path: /var/named/{{ env.cluster.networking.metadata_name }}.db
     insertafter: "entries for the compute nodes"
     line: "{{ env.cluster.nodes.compute.hostname[i] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}. IN A {{ env.cluster.nodes.compute.ip[i] }}"
-  with_sequence: start=0 end={{(env.cluster.nodes.compute.hostname | length) - 1}} stride=1
+  with_sequence: start=0 end={{ (env.cluster.nodes.compute.hostname | length) - 1 }} stride=1
   loop_control:
     extended: yes
     index_var: i
 
 - name: Add infrastructure nodes to DNS forwarding file on bastion if requested
   tags: dns
-  lineinfile:
-    path: /var/named/{{env.cluster.networking.metadata_name}}.db
+  ansible.builtin.lineinfile:
+    path: /var/named/{{ env.cluster.networking.metadata_name }}.db
     insertafter: "entries for extra RHEL VMs"
     line: "{{ env.cluster.nodes.infra.hostname[i] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}. IN A {{ env.cluster.nodes.infra.ip[i] }}"
-  with_sequence: start=0 end={{(env.cluster.nodes.infra.hostname | length) - 1}} stride=1
+  with_sequence: start=0 end={{ (env.cluster.nodes.infra.hostname | length) - 1 }} stride=1
   loop_control:
     extended: yes
     index_var: i
@@ -74,43 +73,43 @@
 
 - name: Template DNS reverse lookup file to bastion
   tags: dns
-  template:
+  ansible.builtin.template:
     src: dns.rev.j2
-    dest: /var/named/{{env.cluster.networking.metadata_name}}.rev
+    dest: /var/named/{{ env.cluster.networking.metadata_name }}.rev
     owner: named
     group: named
-    mode: '0755'
+    mode: "0644"
     backup: yes
 
 - name: Add control nodes to DNS reverse lookup file on bastion
   tags: dns
-  lineinfile:
-    path: /var/named/{{env.cluster.networking.metadata_name}}.rev
+  ansible.builtin.lineinfile:
+    path: /var/named/{{ env.cluster.networking.metadata_name }}.rev
     insertafter: "PTR Record IP address to Hostname"
     line: "{{ env.cluster.nodes.control.ip[i].split('.').3 }}     IN      PTR     {{ env.cluster.nodes.control.hostname[i] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}."
-  with_sequence: start=0 end={{(env.cluster.nodes.control.hostname | length) - 1}} stride=1
+  with_sequence: start=0 end={{ (env.cluster.nodes.control.hostname | length) - 1 }} stride=1
   loop_control:
     extended: yes
     index_var: i
 
 - name: Add compute nodes to DNS reverse lookup file on bastion
   tags: dns
-  lineinfile:
-    path: /var/named/{{env.cluster.networking.metadata_name}}.rev
+  ansible.builtin.lineinfile:
+    path: /var/named/{{ env.cluster.networking.metadata_name }}.rev
     insertafter: "PTR Record IP address to Hostname"
     line: "{{ env.cluster.nodes.compute.ip[i].split('.').3 }}     IN      PTR     {{ env.cluster.nodes.compute.hostname[i] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}."
-  with_sequence: start=0 end={{(env.cluster.nodes.compute.hostname | length) - 1}} stride=1
+  with_sequence: start=0 end={{ (env.cluster.nodes.compute.hostname | length) - 1 }} stride=1
   loop_control:
     extended: yes
     index_var: i
 
 - name: Add infrastructure nodes to DNS reverse lookup file on bastion
   tags: dns
-  lineinfile:
-    path: /var/named/{{env.cluster.networking.metadata_name}}.rev
+  ansible.builtin.lineinfile:
+    path: /var/named/{{ env.cluster.networking.metadata_name }}.rev
     insertafter: "PTR Record IP address to Hostname"
     line: "{{ env.cluster.nodes.infra.ip[i].split('.').3 }}     IN      PTR     {{ env.cluster.nodes.infra.hostname[i] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}."
-  with_sequence: start=0 end={{(env.cluster.nodes.infra.hostname | length) - 1}} stride=1
+  with_sequence: start=0 end={{ (env.cluster.nodes.infra.hostname | length) - 1 }} stride=1
   loop_control:
     extended: yes
     index_var: i
@@ -118,15 +117,25 @@
 
 - name: Template out bastion's resolv.conf file, replacing default
   tags: dns, resolv
-  template:
+  ansible.builtin.template:
     src: resolv.conf.j2
     dest: /etc/resolv.conf
     owner: root
     group: root
-    mode: '644'
+    mode: "644"
 
 - name: Restart named to update changes made to DNS
   tags: dns, resolv
   ansible.builtin.systemd:
-      name: named
-      state: restarted
+    name: named
+    state: restarted
+
+# NetworkManager modifies our /etc/resolv.conf file on next restart or reboot, we need to disable it
+- name: Disable management of /etc/resolv.conf by NetworkManager
+  tags: dns, resolv
+  ansible.builtin.copy:
+    src: 90-dns-none.conf
+    dest: /etc//NetworkManager/conf.d/90-dns-none.conf
+    group: root
+    owner: root
+    mode: "644"

--- a/roles/dns/templates/resolv.conf.j2
+++ b/roles/dns/templates/resolv.conf.j2
@@ -1,2 +1,3 @@
+search {{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}
 nameserver {{ env.cluster.networking.nameserver1 }}
 {{ ('nameserver ' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }}


### PR DESCRIPTION
NetworkManager will update /etc/resolv.conf file on next restart or reboot. We need to disable it.

Signed-off-by: Klaus Smolin <smolin@de.ibm.com>