### PR TITLE
fix: Improve node check

### DIFF
--- a/roles/check_nodes/tasks/main.yaml
+++ b/roles/check_nodes/tasks/main.yaml
@@ -1,19 +1,26 @@
 ---
+- name: Get and print nodes status
+  tags: check_nodes
+  block:
+    - name: Get nodes status
+      tags: check_nodes
+      ansible.builtin.command: oc get nodes
+      register: oc_get_nodes
 
-  - name: Check nodes status
-    tags: check_nodes
-    shell: oc get nodes | awk '{print $1, $2}'
-    register: oc_get_nodes
+    - name: Print nodes status
+      tags: check_nodes
+      ansible.builtin.debug:
+        var: oc_get_nodes.stdout_lines
 
-  - name: Print nodes status
-    tags: check_nodes
-    debug:
-      var: oc_get_nodes.stdout_lines
-
-  - name: Make sure nodes are 'Ready' before continuing
-    tags: check_nodes
-    shell: oc get nodes | awk '{print $2}'
-    register: nodes_check
-    until: ("NotReady" not in nodes_check.stdout)
-    retries: 120
-    delay: 30
+- name: Make sure control and compute nodes are 'Ready' before continuing (retry every 20s)
+  tags: check_nodes
+  ansible.builtin.shell: |
+    set -o pipefail
+    oc get nodes | grep "^{{ node }}" | awk '{print $2}'
+  loop: "{{ env.cluster.nodes.control.hostname + env.cluster.nodes.compute.hostname }}"
+  loop_control:
+    loop_var: node
+  register: cmd_output
+  until: ("Ready" == cmd_output.stdout)
+  retries: 60
+  delay: 20

--- a/roles/check_nodes/tasks/main.yaml
+++ b/roles/check_nodes/tasks/main.yaml
@@ -16,7 +16,7 @@
   tags: check_nodes
   ansible.builtin.shell: |
     set -o pipefail
-    oc get nodes | grep "^{{ node }}" | awk '{print $2}'
+    oc get nodes | grep "^{{ node | lower }}" | awk '{print $2}'
   loop: "{{ env.cluster.nodes.control.hostname + env.cluster.nodes.compute.hostname }}"
   loop_control:
     loop_var: node


### PR DESCRIPTION
Verify the status of all defined control and compute nodes. The old code just checked if reported nodes where 'Ready'. The reported node list was not verified.

Signed-off-by: Klaus Smolin <smolin@de.ibm.com>