### PR TITLE
feat: Improve OCP versioning

### DIFF
--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -133,7 +133,7 @@
 ## 12 - OpenShift Settings
 **Variable Name** | **Description** | **Example**
 :--- | :--- | :---
-**env.openshift.version** | Version of OpenShift you would like to download and install. Use major.minor (i.e. 4.12), it<br /> will pull the latest patch from that minor version. | 4.12 
+**env.openshift.version** | Version of OpenShift you would like to download and install. Use major.minor.patch conventions (i.e. 4.12.0) | 4.12.0
 **env.install_config.api_version** | Kubernetes API version for the cluster. These install_config variables will be passed to the OCP<br /> install_config file. This file is templated in the get_ocp role during the setup_bastion playbook.<br /> To make more fine-tuned adjustments to the install_config, you can find it at<br /> roles/get_ocp/templates/install-config.yaml.j2 | v1
 **env.install_config.compute.architecture** | Computing architecture for the compute nodes. Must be s390x for clusters on IBM zSystems. | s390x
 **env.install_config.compute.hyperthreading** | Enable or disable hyperthreading on compute nodes. Recommended enabled. | Enabled

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -133,7 +133,7 @@
 ## 12 - OpenShift Settings
 **Variable Name** | **Description** | **Example**
 :--- | :--- | :---
-**env.openshift.version** | Version of OpenShift you would like to download and install. Use major.minor.patch conventions (i.e. 4.12.0) | 4.12.0
+**env.openshift.version** | Version of OpenShift you would like to download and install. Use major.minor.patch naming convention. | 4.12.0
 **env.install_config.api_version** | Kubernetes API version for the cluster. These install_config variables will be passed to the OCP<br /> install_config file. This file is templated in the get_ocp role during the setup_bastion playbook.<br /> To make more fine-tuned adjustments to the install_config, you can find it at<br /> roles/get_ocp/templates/install-config.yaml.j2 | v1
 **env.install_config.compute.architecture** | Computing architecture for the compute nodes. Must be s390x for clusters on IBM zSystems. | s390x
 **env.install_config.compute.hyperthreading** | Enable or disable hyperthreading on compute nodes. Recommended enabled. | Enabled

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -130,18 +130,10 @@
 **env.pkgs.kvm** | A list of packages that will be installed on the KVM Host during the setup_kvm_host playbook.<br /> Feel free to add more as needed, just make sure to follow the same list format. | qemu-kvm
 **env.pkgs.bastion** | A list of packages that will be installed on the bastion during the setup_bastion playbook.<br /> Feel free to add more as needed, just make sure to follow the same list format. | haproxy
 
-## 12 - (Optional) Mirror Links
+## 12 - OpenShift Settings
 **Variable Name** | **Description** | **Example**
 :--- | :--- | :---
-**env.openshift.client** | Link to the mirror for the OpenShift client from Red Hat. Feel free to change to a different version, but <br /> make sure it is for s390x architecture. | https://mirror.openshift.com<br />/pub/openshift-v4/s390x/clients<br />/ocp/stable/openshift-<br />client-linux.tar.gz
-**env.openshift.installer** | Link to the mirror for the OpenShift installer from Red Hat.<br /> Feel free to change to a different version, but make sure it is for s390x architecture. | https://mirror.openshift.com<br />/pub/openshift-v4/s390x<br />/clients/ocp/stable/openshift-<br />install-linux.tar.gz
-**env.coreos.kernel** | Link to the mirror of the CoreOS kernel to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version, but make sure it is for s390x architecture. | https://mirror.openshift.com<br />/pub/openshift-v4/s390x<br />/dependencies/rhcos<br />/4.9/latest/rhcos-4.9.0-s390x-<br />live-kernel-s390x
-**env.coreos.initramfs** | Link to the mirror of the CoreOS initramfs to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version, but make sure it is for s390x architecture. | https://mirror.openshift.com<br />/pub/openshift-v4<br />/s390x/dependencies/rhcos<br />/4.9/latest/rhcos-4.9.0-s390x-<br />live-initramfs.s390x.img
-**env.coreos.rootfs** | Link to the mirror of the CoreOS rootfs to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version, but make sure it is for s390x architecture. | https://mirror.openshift.com<br />/pub/openshift-v4<br />/s390x/dependencies/rhcos<br />/4.9/latest/rhcos-4.9.0-<br />s390x-live-rootfs.s390x.img 
-
-## 13 - (Optional) OCP Install Config
-**Variable Name** | **Description** | **Example**
-:--- | :--- | :---
+**env.openshift.version** | Version of OpenShift you would like to download and install. Use major.minor (i.e. 4.12), it<br /> will pull the latest patch from that minor version. | 4.12 
 **env.install_config.api_version** | Kubernetes API version for the cluster. These install_config variables will be passed to the OCP<br /> install_config file. This file is templated in the get_ocp role during the setup_bastion playbook.<br /> To make more fine-tuned adjustments to the install_config, you can find it at<br /> roles/get_ocp/templates/install-config.yaml.j2 | v1
 **env.install_config.compute.architecture** | Computing architecture for the compute nodes. Must be s390x for clusters on IBM zSystems. | s390x
 **env.install_config.compute.hyperthreading** | Enable or disable hyperthreading on compute nodes. Recommended enabled. | Enabled
@@ -153,14 +145,14 @@
 **env.install_config.service_network** | The IP address block for services. The default value is 172.30.0.0/16. The OpenShift SDN<br /> and OVN-Kubernetes network providers support only a single IP address block for the service<br /> network. An array with an IP address block in CIDR format. | 172.30.0.0/16
 **env.install_config.fips** | True or False (boolean) for whether or not to use the United States' Federal Information Processing<br /> Standards (FIPS). Not yet certified on IBM zSystems. Enclosed in 'single quotes'. | 'false'
 
-## 14 - (Optional) Proxy
+## 13 - (Optional) Proxy
 **Variable Name** | **Description** | **Example**
 :--- | :--- | :---
 **proxy_env.http_proxy** | (Optional) A proxy URL to use for creating HTTP connections outside the cluster. Will be<br /> used in the install-config and applied to other Ansible hosts unless set otherwise in<br /> no_proxy below. Must follow this pattern: http://username:pswd>@ip:port | http://ocp-admin:Pa$sw0rd@9.72.10.1:80
 **proxy_env.https_proxy** | (Optional) A proxy URL to use for creating HTTPS connections outside the cluster. Will be<br /> used in the install-config and applied to other Ansible hosts unless set otherwise in<br /> no_proxy below. Must follow this pattern: https://username:pswd@ip:port | https://ocp-admin:Pa$sw0rd@9.72.10.1:80  
 **proxy_env.no_proxy** | (Optional) A comma-separated list (no spaces) of destination domain names, IP<br /> addresses, or other network CIDRs to exclude from proxying. When using a<br /> proxy, all necessary IPs and domains for your cluster will be added automatically. See<br /> roles/get_ocp/templates/install-config.yaml.j2 for more details on the template. <br />Preface a domain with . to match subdomains only. For example, .y.com matches<br /> x.y.com, but not y.com. Use * to bypass the proxy for all listed destinations. | example.com,192.168.10.1
 
-## 15 - (Optional) Misc
+## 14 - (Optional) Misc
 **Variable Name** | **Description** | **Example**
 :--- | :--- | :---
 **env.language** | What language would you like Red Hat Enterprise Linux to use? In UTF-8 language code.<br /> Available languages and their corresponding codes can be found [here](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/5/html-single/international_language_support_guide/index), in the "Locale" column of Table 2.1. | en_US.UTF-8

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -151,16 +151,9 @@ env:
     kvm: [ '@virt', cockpit-machines, libvirt-devel, virt-top, qemu-kvm, python3-lxml, cockpit, lvm2 ]
     bastion: [ haproxy, httpd, bind, bind-utils, expect, firewalld, mod_ssl, python3-policycoreutils, rsync ]
 
-# Section 12 - (Optional) OCP Mirror Links
+# Section 12 - OpenShift Settings
   openshift:
-    client: https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/4.12.0/openshift-client-linux.tar.gz
-    installer: https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/4.12.0/openshift-install-linux.tar.gz
-  coreos:
-    kernel: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.12/latest/rhcos-4.12.0-s390x-live-kernel-s390x
-    initramfs: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.12/latest/rhcos-4.12.0-s390x-live-initramfs.s390x.img
-    rootfs: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.12/latest/rhcos-4.12.0-s390x-live-rootfs.s390x.img
-
-# Section 13 - (Optional) OCP Install Config
+    version: 4.12
   install_config:
     api_version: v1
     compute:
@@ -176,14 +169,14 @@ env:
     service_network: 172.30.0.0/16
     fips: 'false'
 
-# Section 14 - (Optional) Proxy
+# Section 13 - (Optional) Proxy
 
 #proxy_env:
 #  http_proxy: 
 #  https_proxy: 
 #  no_proxy: 
 
-# Section 15 - (Optional) Misc
+# Section 14 - (Optional) Misc
   language: en_US.UTF-8
   timezone: America/New_York
   root_access: false

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -153,7 +153,7 @@ env:
 
 # Section 12 - OpenShift Settings
   openshift:
-    version: 4.12
+    version: 4.12.0
   install_config:
     api_version: v1
     compute:

--- a/roles/create_bootstrap/tasks/main.yaml
+++ b/roles/create_bootstrap/tasks/main.yaml
@@ -15,9 +15,9 @@
     --cpu host \
     --vcpus {{ env.cluster.nodes.bootstrap.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-s390x,initrd=rhcos-live-initramfs.s390x.img \
+    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
     --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda \
-    coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/rhcos-live-rootfs.s390x.img \
+    coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
     ip={{ env.cluster.nodes.bootstrap.ip }}::{{ networking.gateway }}:{{ networking.subnetmask }}:{{ env.cluster.nodes.bootstrap.hostname }}::none:1500 \
     nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} \
     coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/bootstrap.ign" \

--- a/roles/create_compute_nodes/tasks/main.yaml
+++ b/roles/create_compute_nodes/tasks/main.yaml
@@ -11,8 +11,8 @@
     --cpu host \
     --vcpus {{env.cluster.nodes.compute.vcpu}} \
     --network network={{env.bridge_name}} \
-    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-s390x,initrd=rhcos-live-initramfs.s390x.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs.s390x.img ip={{env.cluster.nodes.compute.ip[i]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{env.cluster.nodes.compute.hostname[i]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/worker.ign" \
+    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{env.cluster.nodes.compute.ip[i]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{env.cluster.nodes.compute.hostname[i]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/worker.ign" \
     --wait=-1 \
     --noautoconsole
   with_sequence: start=0 end={{ ( env.cluster.nodes.compute.hostname | length ) - 1 }} stride=1
@@ -32,8 +32,8 @@
     --cpu host \
     --vcpus {{env.cluster.nodes.infra.vcpu}} \
     --network network={{env.bridge_name}} \
-    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-s390x,initrd=rhcos-live-initramfs.s390x.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs.s390x.img ip={{env.cluster.nodes.infra.ip[i]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{env.cluster.nodes.infra.hostname[i]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/worker.ign" \
+    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{env.cluster.nodes.infra.ip[i]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{env.cluster.nodes.infra.hostname[i]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/worker.ign" \
     --wait=-1 \
     --noautoconsole
   with_sequence: start=0 end={{ ( env.cluster.nodes.infra.hostname | length ) - 1}} stride=1
@@ -71,8 +71,8 @@
     --cpu host \
     --vcpus {{env.cluster.nodes.compute.vcpu}} \
     --network network={{env.bridge_name}} \
-    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-s390x,initrd=rhcos-live-initramfs.s390x.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs.s390x.img ip={{compute_ip[i]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{compute_hostname[i]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/worker.ign" \
+    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{compute_ip[i]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{compute_hostname[i]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/worker.ign" \
     --wait=-1 \
     --noautoconsole
   loop: "{{ compute_name | zip(compute_hostname, compute_ip) | list }}"
@@ -92,8 +92,8 @@
     --cpu host \
     --vcpus {{env.cluster.nodes.infra.vcpu}} \
     --network network={{env.bridge_name}} \
-    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-s390x,initrd=rhcos-live-initramfs.s390x.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs.s390x.img ip={{infra_ip[i]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{infra_hostname[i]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/worker.ign" \
+    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{infra_ip[i]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{infra_hostname[i]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/worker.ign" \
     --wait=-1 \
     --noautoconsole
   loop: "{{ infra_name | zip(infra_hostname, infra_ip) | list }}"

--- a/roles/create_control_nodes/tasks/main.yaml
+++ b/roles/create_control_nodes/tasks/main.yaml
@@ -11,8 +11,8 @@
     --cpu host \
     --vcpus {{env.cluster.nodes.control.vcpu}} \
     --network network={{env.bridge_name}} \
-    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-s390x,initrd=rhcos-live-initramfs.s390x.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs.s390x.img ip={{env.cluster.nodes.control.ip[i]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{env.cluster.nodes.control.hostname[i]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/master.ign" \
+    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{env.cluster.nodes.control.ip[i]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{env.cluster.nodes.control.hostname[i]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/master.ign" \
     --graphics none \
     --wait=-1 \
     --noautoconsole
@@ -33,8 +33,8 @@
     --cpu host \
     --vcpus {{env.cluster.nodes.control.vcpu}} \
     --network network={{env.bridge_name}} \
-    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-s390x,initrd=rhcos-live-initramfs.s390x.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs.s390x.img ip={{env.cluster.nodes.control.ip[0]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{env.cluster.nodes.control.hostname[0]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/master.ign" \
+    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{env.cluster.nodes.control.ip[0]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{env.cluster.nodes.control.hostname[0]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/master.ign" \
     --graphics none \
     --wait=-1 \
     --noautoconsole
@@ -51,8 +51,8 @@
     --cpu host \
     --vcpus {{env.cluster.nodes.control.vcpu}} \
     --network network={{env.bridge_name}} \
-    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-s390x,initrd=rhcos-live-initramfs.s390x.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs.s390x.img ip={{env.cluster.nodes.control.ip[1]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{env.cluster.nodes.control.hostname[1]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/master.ign" \
+    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{env.cluster.nodes.control.ip[1]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{env.cluster.nodes.control.hostname[1]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/master.ign" \
     --graphics none \
     --wait=-1 \
     --noautoconsole
@@ -69,8 +69,8 @@
     --cpu host \
     --vcpus {{env.cluster.nodes.control.vcpu}} \
     --network network={{env.bridge_name}} \
-    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-s390x,initrd=rhcos-live-initramfs.s390x.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs.s390x.img ip={{env.cluster.nodes.control.ip[2]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{env.cluster.nodes.control.hostname[2]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/master.ign" \
+    --location /var/lib/libvirt/images,kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{env.bastion.networking.ip}}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{env.cluster.nodes.control.ip[2]}}::{{networking.gateway}}:{{networking.subnetmask}}:{{env.cluster.nodes.control.hostname[2]}}::none:1500 nameserver={{env.cluster.networking.nameserver1}} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{env.bastion.networking.ip}}:8080/ignition/master.ign" \
     --graphics none \
     --wait=-1 \
     --noautoconsole

--- a/roles/get_ocp/tasks/main.yaml
+++ b/roles/get_ocp/tasks/main.yaml
@@ -37,7 +37,7 @@
   get_url:
     url: "https://mirror.openshift.com/pub/openshift-v{{ env.openshift.version | string | split('.') | first }}/{{ env.install_config.control.architecture }}/dependencies/rhcos/{{ ( env.openshift.version | string | split('.') )[:-1] | join('.') }}/{{ env.openshift.version }}/rhcos-live-rootfs.{{ env.install_config.control.architecture }}.img"
     dest: "/var/www/html/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img"
-    mode: '0755'
+    mode: '0644'
 
 - name: Unzip OCP client and installer
   tags: get_ocp

--- a/roles/get_ocp/tasks/main.yaml
+++ b/roles/get_ocp/tasks/main.yaml
@@ -67,7 +67,7 @@
 - name: Use template file to create install-config and backup.
   tags: get_ocp
   vars:
-    use_proxy: "{{ 'True' if (env.proxy.http is defined or env.proxy.https is defined or env.proxy.no is defined) else 'False' }}"
+    use_proxy: "{{ 'True' if (proxy_env.http_proxy is defined or proxy_env.https_proxy is defined or proxy_env.no_proxy is defined) else 'False' }}"
   template:
     src: install-config.yaml.j2
     dest: "{{ item }}"

--- a/roles/get_ocp/tasks/main.yaml
+++ b/roles/get_ocp/tasks/main.yaml
@@ -35,7 +35,7 @@
 - name: Get Red Hat CoreOS rootfs file if it's not there already.
   tags: get_ocp
   get_url:
-    url: "https://mirror.openshift.com/pub/openshift-v{{ env.openshift.version | string | first }}/{{ env.install_config.control.architecture }}/dependencies/rhcos/{{ env.openshift.version }}/latest/rhcos-live-rootfs.{{ env.install_config.control.architecture }}.img"
+    url: "https://mirror.openshift.com/pub/openshift-v{{ env.openshift.version | string | split('.') | first }}/{{ env.install_config.control.architecture }}/dependencies/rhcos/{{ ( env.openshift.version | string | split('.') )[:-1] | join('.') }}/{{ env.openshift.version }}/rhcos-live-rootfs.{{ env.install_config.control.architecture }}.img"
     dest: "/var/www/html/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img"
     mode: '0755'
 
@@ -46,8 +46,8 @@
     dest: /root/ocpinst/
     remote_src: yes
   loop:
-    - "https://mirror.openshift.com/pub/openshift-v{{ env.openshift.version | string | first }}/{{ env.install_config.control.architecture }}/clients/ocp/latest-{{ env.openshift.version }}/openshift-client-linux.tar.gz"
-    - "https://mirror.openshift.com/pub/openshift-v{{ env.openshift.version | string | first }}/{{ env.install_config.control.architecture }}/clients/ocp/latest-{{ env.openshift.version }}/openshift-install-linux.tar.gz"
+    - "https://mirror.openshift.com/pub/openshift-v{{ env.openshift.version | string | split('.') | first }}/{{ env.install_config.control.architecture }}/clients/ocp/{{ env.openshift.version }}/openshift-client-linux.tar.gz"
+    - "https://mirror.openshift.com/pub/openshift-v{{ env.openshift.version | string | split('.') | first }}/{{ env.install_config.control.architecture }}/clients/ocp/{{ env.openshift.version }}/openshift-install-linux.tar.gz"
 
 - name: Copy kubectl, oc, and openshift-install binaries to /usr/local/sbin
   tags: get_ocp

--- a/roles/get_ocp/tasks/main.yaml
+++ b/roles/get_ocp/tasks/main.yaml
@@ -1,16 +1,13 @@
 ---
 
-- name: Delete bin and ignition folders when refresh_ocp_version has been passed as True to command-line via extra-vars.
-  tags: get_ocp, refresh_ocp_version
-  vars:
-    refresh_ocp_version: 'False'
+- name: Delete bin and ignition folders for idempotency.
+  tags: get_ocp
   file:
     path: /var/www/html/{{ item }}
     state: absent
   loop:
     - ignition
     - bin
-  when: refresh_ocp_version == 'True'
 
 - name: Create directory bin for mirrors
   tags: get_ocp
@@ -21,21 +18,6 @@
     mode: '0755'
     owner: "root"
     group: "root"
-
-- name: Check to see if rootfs already exists on bastion
-  tags: get_ocp
-  stat:
-    path: /var/www/html/bin/rhcos-live-rootfs.s390x.img
-  register: rootfs_check
-
-- name: Get Red Hat CoreOS rootfs file if it's not there already.
-  tags: get_ocp
-  get_url:
-    url: "{{ env.coreos.rootfs }}"
-    dest: /var/www/html/bin/rhcos-live-rootfs.s390x.img
-    mode: '0755'
-    force: yes
-  when: rootfs_check.stat.exists == false
 
 - name: Delete OCP download directory for idempotency, because ignition files deprecate after 24 hours.
   tags: get_ocp
@@ -50,6 +32,13 @@
     path: /root/ocpinst
     state: directory
 
+- name: Get Red Hat CoreOS rootfs file if it's not there already.
+  tags: get_ocp
+  get_url:
+    url: "https://mirror.openshift.com/pub/openshift-v{{ env.openshift.version | string | first }}/{{ env.install_config.control.architecture }}/dependencies/rhcos/{{ env.openshift.version }}/latest/rhcos-live-rootfs.{{ env.install_config.control.architecture }}.img"
+    dest: "/var/www/html/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img"
+    mode: '0755'
+
 - name: Unzip OCP client and installer
   tags: get_ocp
   ansible.builtin.unarchive:
@@ -57,15 +46,15 @@
     dest: /root/ocpinst/
     remote_src: yes
   loop:
-    - "{{ env.openshift.client }}"
-    - "{{ env.openshift.installer }}"
+    - "https://mirror.openshift.com/pub/openshift-v{{ env.openshift.version | string | first }}/{{ env.install_config.control.architecture }}/clients/ocp/latest-{{ env.openshift.version }}/openshift-client-linux.tar.gz"
+    - "https://mirror.openshift.com/pub/openshift-v{{ env.openshift.version | string | first }}/{{ env.install_config.control.architecture }}/clients/ocp/latest-{{ env.openshift.version }}/openshift-install-linux.tar.gz"
 
 - name: Copy kubectl, oc, and openshift-install binaries to /usr/local/sbin
   tags: get_ocp
   become: true
   ansible.builtin.copy:
-    src: /root/ocpinst/{{item}}
-    dest: /usr/sbin/{{item}}
+    src: /root/ocpinst/{{ item }}
+    dest: /usr/sbin/{{ item }}
     owner: root
     group: root
     mode: '755'
@@ -75,13 +64,10 @@
     - oc
     - openshift-install
 
-- name: Determine whether proxy info is needed in the install-config.
-  tags: get_ocp
-  set_fact:
-    use_proxy: "{{ 'True' if (proxy_env.http_proxy is defined or proxy_env.https_proxy is defined or proxy_env.no_proxy is defined) else 'False' }}"
-
 - name: Use template file to create install-config and backup.
   tags: get_ocp
+  vars:
+    use_proxy: "{{ 'True' if (env.proxy.http is defined or env.proxy.https is defined or env.proxy.no is defined) else 'False' }}"
   template:
     src: install-config.yaml.j2
     dest: "{{ item }}"

--- a/roles/get_ocp/tasks/main.yaml
+++ b/roles/get_ocp/tasks/main.yaml
@@ -1,13 +1,10 @@
 ---
 
-- name: Delete bin and ignition folders for idempotency.
+- name: Delete ignition folder for idempotency
   tags: get_ocp
   file:
-    path: /var/www/html/{{ item }}
+    path: /var/www/html/ignition
     state: absent
-  loop:
-    - ignition
-    - bin
 
 - name: Create directory bin for mirrors
   tags: get_ocp

--- a/roles/prep_kvm_guests/tasks/main.yaml
+++ b/roles/prep_kvm_guests/tasks/main.yaml
@@ -3,13 +3,14 @@
 - name: Get Red Hat CoreOS kernel and initramfs from URL to /var/lib/libvirt/images
   tags: prep_kvm_guests
   vars:
-    version: "{{ env.openshift.version }}"
+    major_minor_patch: "{{ env.openshift.version }}"
+    major_minor: "{{ ( env.openshift.version | string | split('.') )[:-1] | join('.') }}"
+    major: "{{ env.openshift.version | string | split('.') | first }}"
     arch: "{{ env.install_config.control.architecture }}"
-    major: "{{ env.openshift.version | string | first }}"
   get_url:
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
     mode: '0755'
   loop:
-    - { url: "https://mirror.openshift.com/pub/openshift-v{{ major }}/{{ arch }}/dependencies/rhcos/{{ version }}/latest/rhcos-live-kernel-{{ arch }}", dest: "/var/lib/libvirt/images/rhcos-live-kernel-{{ version }}-{{ arch }}" }
-    - { url: "https://mirror.openshift.com/pub/openshift-v{{ version | string | first }}/{{ arch }}/dependencies/rhcos/{{ version }}/latest/rhcos-live-initramfs.{{ arch }}.img", dest: "/var/lib/libvirt/images/rhcos-live-initramfs-{{ version }}-{{ arch }}.img" }
+    - { url: "https://mirror.openshift.com/pub/openshift-v{{ major }}/{{ arch }}/dependencies/rhcos/{{ major_minor }}/{{ major_minor_patch }}/rhcos-live-kernel-{{ arch }}", dest: "/var/lib/libvirt/images/rhcos-live-kernel-{{ major_minor_patch }}-{{ arch }}" }
+    - { url: "https://mirror.openshift.com/pub/openshift-v{{ major }}/{{ arch }}/dependencies/rhcos/{{ major_minor }}/{{ major_minor_patch }}/rhcos-live-initramfs.{{ arch }}.img", dest: "/var/lib/libvirt/images/rhcos-live-initramfs-{{ major_minor_patch }}-{{ arch }}.img" }

--- a/roles/prep_kvm_guests/tasks/main.yaml
+++ b/roles/prep_kvm_guests/tasks/main.yaml
@@ -1,31 +1,15 @@
 ---
 
-- name: Check to see if kernel already exists on KVM host
+- name: Get Red Hat CoreOS kernel and initramfs from URL to /var/lib/libvirt/images
   tags: prep_kvm_guests
-  stat:
-    path: "/var/lib/libvirt/images/rhcos-live-kernel-s390x"
-  register: kernel_check
-
-- name: Get Red Hat CoreOS kernel
-  tags: prep_kvm_guests
+  vars:
+    version: "{{ env.openshift.version }}"
+    arch: "{{ env.install_config.control.architecture }}"
+    major: "{{ env.openshift.version | string | first }}"
   get_url:
-    url: "{{ env.coreos.kernel }}"
-    dest: "/var/lib/libvirt/images/rhcos-live-kernel-s390x"
+    url: "{{ item.url }}"
+    dest: "{{ item.dest }}"
     mode: '0755'
-    force: yes
-  when: kernel_check.stat.exists == false
-
-- name: Check to see if initramfs already exists on KVM host
-  tags: prep_kvm_guests
-  stat:
-    path: "/var/lib/libvirt/images/rhcos-live-initramfs.s390x.img"
-  register: initramfs_check
-
-- name: Get Red Hat CoreOS initramfs
-  tags: prep_kvm_guests
-  get_url:
-    url: "{{ env.coreos.initramfs }}"
-    dest: "/var/lib/libvirt/images/rhcos-live-initramfs.s390x.img"
-    mode: '0755'
-    force: yes
-  when: initramfs_check.stat.exists == false
+  loop:
+    - { url: "https://mirror.openshift.com/pub/openshift-v{{ major }}/{{ arch }}/dependencies/rhcos/{{ version }}/latest/rhcos-live-kernel-{{ arch }}", dest: "/var/lib/libvirt/images/rhcos-live-kernel-{{ version }}-{{ arch }}" }
+    - { url: "https://mirror.openshift.com/pub/openshift-v{{ version | string | first }}/{{ arch }}/dependencies/rhcos/{{ version }}/latest/rhcos-live-initramfs.{{ arch }}.img", dest: "/var/lib/libvirt/images/rhcos-live-initramfs-{{ version }}-{{ arch }}.img" }


### PR DESCRIPTION
Previous method for selecting the OpenShift version in all.yaml was unnecessarily cumbersome, requiring copying 5 different mirror links to variables.

This make it so you just set one variable env.openshift.version to the desired version (i.e. 4.12) and the automation does the rest.

Signed-off-by: Jacob Emery <jacob.emery@ibm.com>