### PR TITLE
Remove deprecated role

### DIFF
--- a/roles/reset_files/tasks/main.yaml
+++ b/roles/reset_files/tasks/main.yaml
@@ -1,7 +1,0 @@
----
-
-- name: Delete files_to_reset from teardown.yaml
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop: "{{files_to_reset}}"


### PR DESCRIPTION
Remove reset_files role which was used in a deprecated playbook.

Signed-off-by: Jacob Emery <jacob.emery@ibm.com>