### PR TITLE
Additional artifact refresh

### DIFF
--- a/playbooks/reinstall_cluster.yaml
+++ b/playbooks/reinstall_cluster.yaml
@@ -1,6 +1,6 @@
 # Use this if you want to re-install nodes with a new OCP version
 ---
-- name: Refresh initramfs and kernel.
+- name: Update initramfs and kernel.
   hosts: kvm_host
   become: True
   gather_facts: False
@@ -9,7 +9,7 @@
   roles:
     - prep_kvm_guests
 
-- name: Refresh ignitions and other install files.
+- name: Update ignitions and other install files.
   hosts: bastion
   become: True
   vars_files: 

--- a/playbooks/reinstall_cluster.yaml
+++ b/playbooks/reinstall_cluster.yaml
@@ -1,7 +1,16 @@
 # Use this if you want to re-install nodes with a new OCP version
 ---
+- name: Refresh initramfs and kernel.
+  hosts: kvm_host
+  become: True
+  gather_facts: False
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/all.yaml"
+  roles:
+    - prep_kvm_guests
 
-- hosts: bastion
+- name: Refresh ignitions and other install files.
+  hosts: bastion
   become: True
   vars_files: 
     - "{{ inventory_dir }}/group_vars/all.yaml"


### PR DESCRIPTION
Add prep_kvm_guests role call to reinstall_cluster playbook so that new versions of the kernel and initramfs are pulled down if the OCP version changes in inventory.

Signed-off-by: Jacob Emery <jacob.emery@ibm.com>