### PR TITLE
feat: improve delete_nodes role

### DIFF
--- a/roles/delete_nodes/tasks/main.yaml
+++ b/roles/delete_nodes/tasks/main.yaml
@@ -1,5 +1,14 @@
 ---
 
+- name: Delete bootstrap node, if exists
+  tags: delete_nodes
+  ansible.builtin.shell: |
+    set -o pipefail
+    virsh destroy "{{ env.cluster.nodes.bootstrap.vm_name }}" || true
+    virsh undefine "{{ env.cluster.nodes.bootstrap.vm_name }}" --remove-all-storage || true
+  register: delete_bootstrap
+  changed_when: "('destroyed' in delete_bootstrap.stdout) or ('undefined' in delete_bootstrap.stdout)"
+
 - name: Delete control, compute and infra nodes, if exists
   tags: delete_nodes
   ansible.builtin.shell: |
@@ -9,6 +18,8 @@
   loop: "{{ env.cluster.nodes.control.vm_name + env.cluster.nodes.compute.vm_name \
     if env.cluster.nodes.infra.vm_name is not defined \
     else env.cluster.nodes.control.vm_name + env.cluster.nodes.compute.vm_name + env.cluster.nodes.infra.vm_name }}"
+  register: delete_nodes
+  changed_when: "('destroyed' in delete_nodes.stdout) or ('undefined' in delete_nodes.stdout)"
 
 - name: Get and print virsh list
   tags: delete_nodes


### PR DESCRIPTION
Add deletion of the bootstrap node to the delete_nodes role, in case of restarting 6_create_nodes before bootstrap is already deleted.

Add changed_when parameter so that "ok" is given when nodes are not destroyed or undefined, and "changed" when they are.

Signed-off-by: Jacob Emery <jacob.emery@ibm.com>