### PR TITLE
fix: Add gitignore to inventories

### DIFF
--- a/inventories/.gitignore
+++ b/inventories/.gitignore
@@ -1,0 +1,3 @@
+/*
+!.gitignore
+!default


### PR DESCRIPTION
Add this gitignore file to allow for the creation, and use of, alternate inventories, while avoiding inadvertently pushing them to a public repo.

The desired inventory could then easily be selected (and switched between) by altering the 'inventory=inventories/<desired-inventory>' line in ansible.cfg