### PR TITLE
fix: Remove '3_setup_kvm_host' from 'pre-existing_site' playbook

### DIFF
--- a/playbooks/pre-existing_site.yaml
+++ b/playbooks/pre-existing_site.yaml
@@ -2,7 +2,6 @@
 ---
 
 - import_playbook: 0_setup.yaml
-- import_playbook: 3_setup_kvm_host.yaml
 - import_playbook: 4_create_bastion.yaml
 - import_playbook: 5_setup_bastion.yaml
 - import_playbook: 6_create_nodes.yaml


### PR DESCRIPTION
Sudo access is required to setup a KVM host. In a pre-existing env, we assume that the KVM host is already installed.