### PR TITLE
fix: Separate RHCOS and OCP versions

### DIFF
--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -174,7 +174,7 @@
 
 **Variable Name** | **Description** | **Example**
 :--- | :--- | :---
-**rhcos_baseurl** | Link to the mirror of the CoreOS files to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version. | https://mirror.openshift.com<br />/pub/openshift-v4/s390x<br />/dependencies/rhcos<br />/4.12/4.12.3/
+**rhcos_download_url** | Link to the mirror of the CoreOS files to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version. | https://mirror.openshift.com<br />/pub/openshift-v4/s390x<br />/dependencies/rhcos<br />/4.12/4.12.3/
 **rhcos_os_variant** | CoreOS base OS. Use the OS string as defined in 'osinfo-query os -f short-id' | rhel8.6
 **rhcos_live_kernel** | CoreOS kernel filename to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version | rhcos-4.12.3-s390x-live-kernel-s390x
 **rhcos_live_initrd** | CoreOS initramfs to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version. | rhcos-4.12.3-s390x-live-initramfs.s390x.img

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -174,8 +174,8 @@
 
 **Variable Name** | **Description** | **Example**
 :--- | :--- | :---
-**rhcos_download_url** | Link to the mirror of the CoreOS files to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version. | https://mirror.openshift.com<br />/pub/openshift-v4/s390x<br />/dependencies/rhcos<br />/4.12/4.12.3/
+**rhcos_download_url** | Link to the CoreOS files to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version. | https://mirror.openshift.com<br />/pub/openshift-v4/s390x<br />/dependencies/rhcos<br />/4.12/4.12.3/
 **rhcos_os_variant** | CoreOS base OS. Use the OS string as defined in 'osinfo-query os -f short-id' | rhel8.6
-**rhcos_live_kernel** | CoreOS kernel filename to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version | rhcos-4.12.3-s390x-live-kernel-s390x
-**rhcos_live_initrd** | CoreOS initramfs to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version. | rhcos-4.12.3-s390x-live-initramfs.s390x.img
-**rhcos_live_rootfs** | CoreOS rootfs to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version. | rhcos-4.12.3-s390x-live-rootfs.s390x.img
+**rhcos_live_kernel** | CoreOS kernel filename to be used for the bootstrap, control and compute nodes. | rhcos-4.12.3-s390x-live-kernel-s390x
+**rhcos_live_initrd** | CoreOS initramfs to be used for the bootstrap, control and compute nodes. | rhcos-4.12.3-s390x-live-initramfs.s390x.img
+**rhcos_live_rootfs** | CoreOS rootfs to be used for the bootstrap, control and compute nodes. | rhcos-4.12.3-s390x-live-rootfs.s390x.img

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -169,3 +169,13 @@
 **env.jumphost.user** | (Optional) The user name to login to the jumphost. | admin
 **env.jumphost.pass** | (Optional) The password for user to login to the jumphost. | ch4ngeMe!
 **env.jumphost.path_to_keypair** | (Optional) The absolute path to the public key file on the jumphost to be copied to the bastion. | /home/admin/.ssh/id_rsa.pub
+
+## 15 - RHCOS (CoreOS)
+
+**Variable Name** | **Description** | **Example**
+:--- | :--- | :---
+**rhcos_baseurl** | Link to the mirror of the CoreOS files to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version. | https://mirror.openshift.com<br />/pub/openshift-v4/s390x<br />/dependencies/rhcos<br />/4.12/4.12.3/
+**rhcos_os_variant** | CoreOS base OS. Use the OS string as defined in 'osinfo-query os -f short-id' | rhel8.6
+**rhcos_live_kernel** | CoreOS kernel filename to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version | rhcos-4.12.3-s390x-live-kernel-s390x
+**rhcos_live_initrd** | CoreOS initramfs to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version. | rhcos-4.12.3-s390x-live-initramfs.s390x.img
+**rhcos_live_rootfs** | CoreOS rootfs to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version. | rhcos-4.12.3-s390x-live-rootfs.s390x.img

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -188,12 +188,24 @@ env:
   ansible_key_name: ansible-ocpz
   ocp_ssh_key_comment: OpenShift key
   bridge_name: macvtap
-  network_mode: 
+  network_mode:
 
 #jumphost if network mode is NAT
-  jumphost:     
-    name: 
+  jumphost:
+    name:
     ip:
-    user: 
-    pass:  
+    user:
+    pass:
     path_to_keypair:
+
+# RHCOS variables
+# rhcos_baseurl with '/' at the end !
+rhcos_baseurl: "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.12/4.12.3/"
+
+# For rhcos_os_variant use the OS string as defined in 'osinfo-query os -f short-id'
+rhcos_os_variant: rhel8.6
+
+# RHCOS live image filenames
+rhcos_live_kernel: "rhcos-4.12.3-s390x-live-kernel-s390x"
+rhcos_live_initrd: "rhcos-4.12.3-s390x-live-initramfs.s390x.img"
+rhcos_live_rootfs: "rhcos-4.12.3-s390x-live-rootfs.s390x.img"

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -198,7 +198,8 @@ env:
     pass:
     path_to_keypair:
 
-# RHCOS variables
+# Section 15 - RHCOS (CoreOS)
+
 # rhcos_baseurl with '/' at the end !
 rhcos_baseurl: "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.12/4.12.3/"
 

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -200,8 +200,8 @@ env:
 
 # Section 15 - RHCOS (CoreOS)
 
-# rhcos_baseurl with '/' at the end !
-rhcos_baseurl: "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.12/4.12.3/"
+# rhcos_download_url with '/' at the end !
+rhcos_download_url: "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.12/4.12.3/"
 
 # For rhcos_os_variant use the OS string as defined in 'osinfo-query os -f short-id'
 rhcos_os_variant: rhel8.6

--- a/roles/create_bastion/tasks/main.yaml
+++ b/roles/create_bastion/tasks/main.yaml
@@ -55,11 +55,11 @@
 - name: Boot and kickstart bastion. To monitor, login to your KVM host and run 'virsh console <bastion VM name>'
   tags: create_bastion, virt-install
   ansible.builtin.shell: |
-    set -o pipefail
     virsh destroy {{ env.bastion.vm_name }} || true
     virsh undefine {{ env.bastion.vm_name }} --remove-all-storage || true
     virt-install \
     --name {{ env.bastion.vm_name }} \
+    --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
     --memory={{ env.bastion.resources.ram }} \
     --vcpus={{ env.bastion.resources.vcpu }} \

--- a/roles/create_bootstrap/tasks/main.yaml
+++ b/roles/create_bootstrap/tasks/main.yaml
@@ -4,20 +4,20 @@
 - name: Start bootstrap installation
   tags: create_bootstrap
   ansible.builtin.shell: |
-    set -o pipefail
     virsh destroy {{ env.cluster.nodes.bootstrap.vm_name }} || true
     virsh undefine {{ env.cluster.nodes.bootstrap.vm_name }} --remove-all-storage || true
     virt-install \
     --name {{ env.cluster.nodes.bootstrap.vm_name }} \
+    --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.bootstrap.disk_size }}  \
     --ram {{ env.cluster.nodes.bootstrap.ram }} \
     --cpu host \
     --vcpus {{ env.cluster.nodes.bootstrap.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ storage.pool_path }},kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
+    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
     --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda \
-    coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
+    coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} \
     ip={{ env.cluster.nodes.bootstrap.ip }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.bootstrap.hostname }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}::none:1500 \
     nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} \
     coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/bootstrap.ign" \

--- a/roles/create_bootstrap/tasks/main.yaml
+++ b/roles/create_bootstrap/tasks/main.yaml
@@ -15,7 +15,7 @@
     --cpu host \
     --vcpus {{ env.cluster.nodes.bootstrap.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
     --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda \
     coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} \
     ip={{ env.cluster.nodes.bootstrap.ip }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.bootstrap.hostname }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}::none:1500 \

--- a/roles/create_compute_nodes/tasks/main.yaml
+++ b/roles/create_compute_nodes/tasks/main.yaml
@@ -2,17 +2,18 @@
 
 - name: Install CoreOS on compute nodes
   tags: create_compute_nodes
-  command: |
+  shell: |
     virt-install \
     --name {{ env.cluster.nodes.compute.vm_name[i] }} \
+    --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
     --ram {{ env.cluster.nodes.compute.ram }} \
     --cpu host \
     --vcpus {{ env.cluster.nodes.compute.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ storage.pool_path }},kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{ env.cluster.nodes.compute.ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.compute.hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
+    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ env.cluster.nodes.compute.ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.compute.hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
     --wait=-1 \
     --noautoconsole
   with_sequence: start=0 end={{ ( env.cluster.nodes.compute.hostname | length ) - 1 }} stride=1
@@ -23,17 +24,18 @@
 
 - name: Install CoreOS on infra nodes
   tags: create_compute_nodes
-  command: |
+  shell: |
     virt-install \
     --name {{ env.cluster.nodes.infra.vm_name[i] }} \
+    --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }}  \
     --ram {{ env.cluster.nodes.infra.ram }} \
     --cpu host \
     --vcpus {{ env.cluster.nodes.infra.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ storage.pool_path }},kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{ env.cluster.nodes.infra.ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.infra.hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
+    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ env.cluster.nodes.infra.ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.infra.hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
     --wait=-1 \
     --noautoconsole
   with_sequence: start=0 end={{ ( env.cluster.nodes.infra.hostname | length ) - 1}} stride=1
@@ -62,17 +64,18 @@
 
 - name: Create CoreOS compute nodes on KVM hosts, if cluster is to be highly available.
   tags: create_compute_nodes
-  command: |
+  shell: |
     virt-install \
     --name {{ compute_name[i] }} \
+    --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
     --ram {{ env.cluster.nodes.compute.ram }} \
     --cpu host \
     --vcpus {{ env.cluster.nodes.compute.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ storage.pool_path }},kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{ compute_ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ compute_hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
+    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ compute_ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ compute_hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
     --wait=-1 \
     --noautoconsole
   loop: "{{ compute_name | zip(compute_hostname, compute_ip) | list }}"
@@ -83,17 +86,18 @@
 
 - name: Create CoreOS infra nodes on KVM hosts, if cluster is to be highly available.
   tags: create_compute_nodes
-  command: |
+  shell: |
     virt-install \
     --name {{ infra_name[i] }} \
+    --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }}  \
     --ram {{ env.cluster.nodes.infra.ram }} \
     --cpu host \
     --vcpus {{ env.cluster.nodes.infra.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ storage.pool_path }},kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{ infra_ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ infra_hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
+    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ infra_ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ infra_hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
     --wait=-1 \
     --noautoconsole
   loop: "{{ infra_name | zip(infra_hostname, infra_ip) | list }}"

--- a/roles/create_compute_nodes/tasks/main.yaml
+++ b/roles/create_compute_nodes/tasks/main.yaml
@@ -12,7 +12,7 @@
     --cpu host \
     --vcpus {{ env.cluster.nodes.compute.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
     --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ env.cluster.nodes.compute.ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.compute.hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
     --wait=-1 \
     --noautoconsole
@@ -34,7 +34,7 @@
     --cpu host \
     --vcpus {{ env.cluster.nodes.infra.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
     --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ env.cluster.nodes.infra.ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.infra.hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
     --wait=-1 \
     --noautoconsole
@@ -74,7 +74,7 @@
     --cpu host \
     --vcpus {{ env.cluster.nodes.compute.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
     --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ compute_ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ compute_hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
     --wait=-1 \
     --noautoconsole
@@ -96,7 +96,7 @@
     --cpu host \
     --vcpus {{ env.cluster.nodes.infra.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
     --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ infra_ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ infra_hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
     --wait=-1 \
     --noautoconsole

--- a/roles/create_control_nodes/tasks/main.yaml
+++ b/roles/create_control_nodes/tasks/main.yaml
@@ -2,17 +2,18 @@
 
 - name: Create CoreOS control nodes on the the KVM host.
   tags: create_control_nodes
-  command: |
+  shell: |
     virt-install \
     --name {{ env.cluster.nodes.control.vm_name[i] }} \
+    --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
-    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }} \
     --ram {{ env.cluster.nodes.control.ram }} \
     --cpu host \
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ storage.pool_path }},kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{ env.cluster.nodes.control.ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.control.hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
+    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ env.cluster.nodes.control.ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.control.hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
     --graphics none \
     --wait=-1 \
     --noautoconsole
@@ -24,17 +25,18 @@
 
 - name: Create the first CoreOS control node on the first KVM host, if cluster is to be highly available.
   tags: create_control_nodes
-  command: |
+  shell: |
     virt-install \
     --name {{ env.cluster.nodes.control.vm_name[0] }} \
+    --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
     --cpu host \
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ storage.pool_path }},kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{ env.cluster.nodes.control.ip[0] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.control.hostname[0] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
+    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ env.cluster.nodes.control.ip[0] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.control.hostname[0] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
     --graphics none \
     --wait=-1 \
     --noautoconsole
@@ -42,17 +44,18 @@
 
 - name: Create the second CoreOS control node on the second KVM host, if cluster is to be highly available.
   tags: create_control_nodes
-  command: |
+  shell: |
     virt-install \
     --name {{ env.cluster.nodes.control.vm_name[1] }} \
+    --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
     --cpu host \
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ storage.pool_path }},kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{ env.cluster.nodes.control.ip[1] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.control.hostname[1] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
+    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ env.cluster.nodes.control.ip[1] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.control.hostname[1] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
     --graphics none \
     --wait=-1 \
     --noautoconsole
@@ -60,17 +63,18 @@
 
 - name: Create the third CoreOS control node on the third KVM host, if cluster is to be highly available.
   tags: create_control_nodes
-  command: |
+  shell: |
     virt-install \
     --name {{ env.cluster.nodes.control.vm_name[2] }} \
+    --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
     --cpu host \
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ storage.pool_path }},kernel=rhcos-live-kernel-{{ env.openshift.version }}-{{ env.install_config.control.architecture }},initrd=rhcos-live-initramfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img \
-    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img ip={{ env.cluster.nodes.control.ip[2] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.control.hostname[2] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
+    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ env.cluster.nodes.control.ip[2] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.control.hostname[2] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
     --graphics none \
     --wait=-1 \
     --noautoconsole

--- a/roles/create_control_nodes/tasks/main.yaml
+++ b/roles/create_control_nodes/tasks/main.yaml
@@ -12,7 +12,7 @@
     --cpu host \
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
     --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ env.cluster.nodes.control.ip[i] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.control.hostname[i] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
     --graphics none \
     --wait=-1 \
@@ -35,7 +35,7 @@
     --cpu host \
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
     --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ env.cluster.nodes.control.ip[0] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.control.hostname[0] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
     --graphics none \
     --wait=-1 \
@@ -54,7 +54,7 @@
     --cpu host \
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
     --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ env.cluster.nodes.control.ip[1] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.control.hostname[1] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
     --graphics none \
     --wait=-1 \
@@ -73,7 +73,7 @@
     --cpu host \
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
-    --location {{ rhcos_baseurl }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
+    --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
     --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url=http://{{ env.bastion.networking.ip }}:8080/bin/{{ rhcos_live_rootfs }} ip={{ env.cluster.nodes.control.ip[2] }}::{{ env.cluster.networking.gateway }}:{{ env.cluster.networking.subnetmask }}:{{ env.cluster.nodes.control.hostname[2] }}::none:1500 nameserver={{ env.cluster.networking.nameserver1 }} {{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }} coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
     --graphics none \
     --wait=-1 \

--- a/roles/get_ocp/tasks/main.yaml
+++ b/roles/get_ocp/tasks/main.yaml
@@ -31,8 +31,8 @@
 - name: Get Red Hat CoreOS rootfs file if it's not there already.
   tags: get_ocp
   get_url:
-    url: "https://mirror.openshift.com/pub/openshift-v{{ env.openshift.version | string | split('.') | first }}/{{ env.install_config.control.architecture }}/dependencies/rhcos/{{ ( env.openshift.version | string | split('.') )[:-1] | join('.') }}/{{ env.openshift.version }}/rhcos-live-rootfs.{{ env.install_config.control.architecture }}.img"
-    dest: "/var/www/html/bin/rhcos-live-rootfs-{{ env.openshift.version }}-{{ env.install_config.control.architecture }}.img"
+    url: "{{ rhcos_baseurl }}{{ rhcos_live_rootfs }}"
+    dest: "/var/www/html/bin/{{ rhcos_live_rootfs }}"
     mode: "0644"
 
 - name: Unzip OCP client and installer

--- a/roles/get_ocp/tasks/main.yaml
+++ b/roles/get_ocp/tasks/main.yaml
@@ -31,7 +31,7 @@
 - name: Get Red Hat CoreOS rootfs file if it's not there already.
   tags: get_ocp
   get_url:
-    url: "{{ rhcos_baseurl }}{{ rhcos_live_rootfs }}"
+    url: "{{ rhcos_download_url }}{{ rhcos_live_rootfs }}"
     dest: "/var/www/html/bin/{{ rhcos_live_rootfs }}"
     mode: "0644"
 

--- a/roles/prep_kvm_guests/tasks/main.yaml
+++ b/roles/prep_kvm_guests/tasks/main.yaml
@@ -1,16 +1,16 @@
 ---
 
-- name: Get Red Hat CoreOS kernel and initramfs from URL to <storage.pool_path>
-  tags: prep_kvm_guests
-  vars:
-    major_minor_patch: "{{ env.openshift.version }}"
-    major_minor: "{{ ( env.openshift.version | string | split('.') )[:-1] | join('.') }}"
-    major: "{{ env.openshift.version | string | split('.') | first }}"
-    arch: "{{ env.install_config.control.architecture }}"
-  get_url:
-    url: "{{ item.url }}"
-    dest: "{{ item.dest }}"
-    mode: '0755'
-  loop:
-    - { url: "https://mirror.openshift.com/pub/openshift-v{{ major }}/{{ arch }}/dependencies/rhcos/{{ major_minor }}/{{ major_minor_patch }}/rhcos-live-kernel-{{ arch }}", dest: "{{ storage.pool_path }}/rhcos-live-kernel-{{ major_minor_patch }}-{{ arch }}" }
-    - { url: "https://mirror.openshift.com/pub/openshift-v{{ major }}/{{ arch }}/dependencies/rhcos/{{ major_minor }}/{{ major_minor_patch }}/rhcos-live-initramfs.{{ arch }}.img", dest: "{{ storage.pool_path }}/rhcos-live-initramfs-{{ major_minor_patch }}-{{ arch }}.img" }
+# - name: Get Red Hat CoreOS kernel and initramfs from URL to <storage.pool_path>
+#   tags: prep_kvm_guests
+#   vars:
+#     major_minor_patch: "{{ env.openshift.version }}"
+#     major_minor: "{{ ( env.openshift.version | string | split('.') )[:-1] | join('.') }}"
+#     major: "{{ env.openshift.version | string | split('.') | first }}"
+#     arch: "{{ env.install_config.control.architecture }}"
+#   get_url:
+#     url: "{{ item.url }}"
+#     dest: "{{ item.dest }}"
+#     mode: '0755'
+#   loop:
+#     - { url: "https://mirror.openshift.com/pub/openshift-v{{ major }}/{{ arch }}/dependencies/rhcos/{{ major_minor }}/{{ major_minor_patch }}/rhcos-live-kernel-{{ arch }}", dest: "{{ storage.pool_path }}/rhcos-live-kernel-{{ major_minor_patch }}-{{ arch }}" }
+#     - { url: "https://mirror.openshift.com/pub/openshift-v{{ major }}/{{ arch }}/dependencies/rhcos/{{ major_minor }}/{{ major_minor_patch }}/rhcos-live-initramfs.{{ arch }}.img", dest: "{{ storage.pool_path }}/rhcos-live-initramfs-{{ major_minor_patch }}-{{ arch }}.img" }


### PR DESCRIPTION
This patch provides the user the ability to specify the OCP and the RHCOS version separately.