### PR TITLE
chore: Use new OCP version and download variables

### DIFF
--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -136,7 +136,6 @@
 ## 12 - OpenShift Settings
 **Variable Name** | **Description** | **Example**
 :--- | :--- | :---
-**env.openshift.version** | Version of OpenShift you would like to download and install. Use major.minor.patch naming convention. | 4.12.0
 **env.install_config.api_version** | Kubernetes API version for the cluster. These install_config variables will be passed to the OCP<br /> install_config file. This file is templated in the get_ocp role during the setup_bastion playbook.<br /> To make more fine-tuned adjustments to the install_config, you can find it at<br /> roles/get_ocp/templates/install-config.yaml.j2 | v1
 **env.install_config.compute.architecture** | Computing architecture for the compute nodes. Must be s390x for clusters on IBM zSystems. | s390x
 **env.install_config.compute.hyperthreading** | Enable or disable hyperthreading on compute nodes. Recommended enabled. | Enabled
@@ -160,7 +159,7 @@
 :--- | :--- | :---
 **env.language** | What language would you like Red Hat Enterprise Linux to use? In UTF-8 language code.<br /> Available languages and their corresponding codes can be found [here](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/5/html-single/international_language_support_guide/index), in the "Locale" column of Table 2.1. | en_US.UTF-8
 **env.timezone** | Which timezone would you like Red Hat Enterprise Linux to use? A list of available timezone<br /> options can be found [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). | America/New_York
-**env.keyboard** | Which keyboard layout would you like Red Hat Enterprise Linux to use?  | us 
+**env.keyboard** | Which keyboard layout would you like Red Hat Enterprise Linux to use?  | us
 **env.ansible_key_name** | (Optional) Name of the SSH key that Ansible will use to connect to hosts. | ansible-ocpz
 **env.ocp_key_name** | Comment to describe the SSH key used for OCP. Arbitrary value. | OCPZ-01 key
 **env.bridge_name** | (Optional) Name of the macvtap bridge that will be created on the KVM host or in case of NAT the name of the NAT network defenition (usually it is 'default'). If NAT is being used and a jumphost is needed, the parameters network_mode, jumphost.name, jumphost.user and jumphost.pass must be specified, too. In case of default (NAT) network verify that the configured IP ranges does not interfere with the IPs defined for the controle and compute nodes. Modify the default network (dhcp range setting) to prevent issues with VMs using dhcp and OCP nodes having fixed IPs.| macvtap-net
@@ -171,10 +170,13 @@
 **env.jumphost.pass** | (Optional) The password for user to login to the jumphost. | ch4ngeMe!
 **env.jumphost.path_to_keypair** | (Optional) The absolute path to the public key file on the jumphost to be copied to the bastion. | /home/admin/.ssh/id_rsa.pub
 
-## 15 - RHCOS (CoreOS)
+## 15 - OCP and RHCOS (CoreOS)
 
 **Variable Name** | **Description** | **Example**
 :--- | :--- | :---
+**ocp_download_url** | Link to the mirror for the OpenShift client and installer from Red Hat. | https://mirror.openshift.com<br />/pub/openshift-v4/multi<br />/clients/ocp/4.13.1/s390x/
+**ocp_client_tgz** | OpenShift client filename (tar.gz). | openshift-client-linux.tar.gz
+**ocp_install_tgz** | OpenShift installer filename (tar.gz). | openshift-install-linux.tar.gz
 **rhcos_download_url** | Link to the CoreOS files to be used for the bootstrap, control and compute nodes.<br /> Feel free to change to a different version. | https://mirror.openshift.com<br />/pub/openshift-v4/s390x<br />/dependencies/rhcos<br />/4.12/4.12.3/
 **rhcos_os_variant** | CoreOS base OS. Use the OS string as defined in 'osinfo-query os -f short-id' | rhel8.6
 **rhcos_live_kernel** | CoreOS kernel filename to be used for the bootstrap, control and compute nodes. | rhcos-4.12.3-s390x-live-kernel-s390x

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -159,8 +159,6 @@ env:
     hypershift: [ make, jq, git, virt-install ]
 
 # Section 12 - OpenShift Settings
-  openshift:
-    version: 4.12.0
   install_config:
     api_version: v1
     compute:
@@ -201,7 +199,13 @@ env:
     path_to_keypair:
 
 
-# Section 15 - RHCOS (CoreOS)
+# Section 15 - OCP and RHCOS (CoreOS)
+
+# ocp_download_url with '/' at the end !
+ocp_download_url: "https://mirror.openshift.com/pub/openshift-v4/multi/clients/ocp/4.13.1/s390x/"
+# ocp client and installer filenames
+ocp_client_tgz: "openshift-client-linux.tar.gz"
+ocp_install_tgz: "openshift-install-linux.tar.gz"
 
 # rhcos_download_url with '/' at the end !
 rhcos_download_url: "https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.12/4.12.3/"
@@ -217,25 +221,25 @@ rhcos_live_rootfs: "rhcos-4.12.3-s390x-live-rootfs.s390x.img"
 # Section 16 - Hypershift
 
 hypershift:
-  kvm_host: 
+  kvm_host:
   kvm_host_user:
-  bastion_hypershift: 
+  bastion_hypershift:
   bastion_hypershift_user:
-  mgmt_cluster_nameserver:  
+  mgmt_cluster_nameserver:
 
   go_version: "1.19.5"  # Change this if you want to install any other version  of go
-  oc_url: 
+  oc_url:
 
   #Hosted Control Plane Parameters
 
   hcp:
     clusters_namespace:
-    hosted_cluster_name: 
+    hosted_cluster_name:
     basedomain:
     pull_secret_file: /root/ansible_workdir/auth_file
-    ocp_release: 
-    machine_cidr:  
-    arch: 
+    ocp_release:
+    machine_cidr:
+    arch:
     # Make sure to enclose pull_secret in 'single quotes'
     pull_secret:
 
@@ -245,10 +249,10 @@ hypershift:
 
   asc:
     url_for_ocp_release_file:
-    db_volume_size: 
+    db_volume_size:
     fs_volume_size:
     ocp_version:
-    iso_url:   
+    iso_url:
     root_fs_url:
     mce_namespace: "multicluster-engine" # This is the Recommended Namespace for Multicluster Engine operator
 

--- a/roles/get_ocp/tasks/main.yaml
+++ b/roles/get_ocp/tasks/main.yaml
@@ -42,8 +42,8 @@
     dest: /root/ocpinst/
     remote_src: yes
   loop:
-    - "https://mirror.openshift.com/pub/openshift-v{{ env.openshift.version | string | split('.') | first }}/{{ env.install_config.control.architecture }}/clients/ocp/{{ env.openshift.version }}/openshift-client-linux.tar.gz"
-    - "https://mirror.openshift.com/pub/openshift-v{{ env.openshift.version | string | split('.') | first }}/{{ env.install_config.control.architecture }}/clients/ocp/{{ env.openshift.version }}/openshift-install-linux.tar.gz"
+    - "{{ ocp_download_url }}{{ ocp_client_tgz }}"
+    - "{{ ocp_download_url }}{{ ocp_install_tgz }}"
 
 - name: Copy kubectl, oc, and openshift-install binaries to /usr/local/sbin
   tags: get_ocp


### PR DESCRIPTION
With this patch you are able to test OCP nightly builds.