### PR TITLE
fix: Remove uuid from storage template file

### DIFF
--- a/roles/configure_storage/templates/vdisk.xml.j2
+++ b/roles/configure_storage/templates/vdisk.xml.j2
@@ -1,6 +1,5 @@
 <pool type='dir'>
   <name>{{ env.cluster.networking.metadata_name }}-vdisk</name>
-  <uuid>2da14d33-c8a8-4554-98f9-37fc6d9b0f90</uuid>
   <capacity unit='gigabytes'>0</capacity>
   <allocation unit='gigabytes'>0</allocation>
   <available unit='gigabytes'>0</available>


### PR DESCRIPTION
The storage pool uuid is defined during creation of a new storage pool. It should not be part of the template file.