### PR TITLE
fix: Update Bastion DNS entries only when enabled

### DIFF
--- a/playbooks/create_compute_node.yaml
+++ b/playbooks/create_compute_node.yaml
@@ -43,6 +43,7 @@
     - role: update_ignition_files
 
     - role: dns_update
+      when: env.bastion.options.dns
       param_dns_cmd: add
       param_dns_hostname: "{{ day2_compute_node.vm_hostname }}"
       param_dns_ip: "{{ day2_compute_node.vm_ip }}"

--- a/playbooks/create_compute_node.yaml
+++ b/playbooks/create_compute_node.yaml
@@ -43,7 +43,7 @@
     - role: update_ignition_files
 
     - role: dns_update
-      when: env.bastion.options.dns
+      when: env.bastion.options.dns is defined and env.bastion.options.dns
       param_dns_cmd: add
       param_dns_hostname: "{{ day2_compute_node.vm_hostname }}"
       param_dns_ip: "{{ day2_compute_node.vm_ip }}"

--- a/playbooks/delete_compute_node.yaml
+++ b/playbooks/delete_compute_node.yaml
@@ -36,6 +36,7 @@
       param_compute_node: "{{ day2_compute_node }}"
 
     - role: dns_update
+      when: env.bastion.options.dns
       param_dns_cmd: delete
       param_dns_hostname: "{{ day2_compute_node.vm_hostname }}"
       param_dns_ip: "{{ day2_compute_node.vm_ip }}"

--- a/playbooks/delete_compute_node.yaml
+++ b/playbooks/delete_compute_node.yaml
@@ -36,7 +36,7 @@
       param_compute_node: "{{ day2_compute_node }}"
 
     - role: dns_update
-      when: env.bastion.options.dns
+      when: env.bastion.options.dns is defined and env.bastion.options.dns
       param_dns_cmd: delete
       param_dns_hostname: "{{ day2_compute_node.vm_hostname }}"
       param_dns_ip: "{{ day2_compute_node.vm_ip }}"


### PR DESCRIPTION
Update Bastion DNS entries only when enabled.