### PR TITLE
feat: Static IP support for agents using NMState and MCE operator install  - Hypershift

### DIFF
--- a/docs/run-the-playbooks-for-hypershift.md
+++ b/docs/run-the-playbooks-for-hypershift.md
@@ -1,8 +1,6 @@
 # Run the Playbooks
 ## Prerequisites
-* Running OCP Cluster ( Management Cluster ) 
-* Multi Cluster Engine (MCE) Operator installed on Management Cluster.
-* MCE instance created and hypershift-preview component enabled.
+* Running OCP Cluster ( Management Cluster )  
 * KVM host with root user access
 
 ### Network Prerequisites

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -224,7 +224,7 @@
 **hypershift.agents_parms.static_ip_parms.interface** | Interface for agents for configuring NMStateConfig | eth0
 **hypershift.agents_parms.static_ip_parms.generate_mac_addr** | true or false - set to false if you want to use a specific mac addresses for agents | true
 **hypershift.agents_parms.agents_count** | Number of agents for the hosted cluster <br /> The same number of compute nodes will be attached to Hosted Cotrol Plane | 2
-**hypershift.agents_parms.agent_mac_addr** | Give here list of macaddresses for the agents <br /> These mac addresses should be configured in DHCP if you are using dynamic IPs for Agents | [ 52:54:00:d9:5b:d9 , 52:54:00:ba:d3:f7 ]
+**hypershift.agents_parms.agent_mac_addr** | Give here list of macaddresses for the agents <br /> These mac addresses should be configured in DHCP if you are using dynamic IPs for Agents | - 52:54:00:ba:d3:f7 
 **hypershift.agents_parms.disk_size** | Disk size for agents | 100G
 **hypershift.agents_parms.ram** | RAM for agents | 16384
 **hypershift.agents_parms.vcpus** | vCPUs for agents | 4

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -222,7 +222,6 @@
 **hypershift.agents_parms.static_ip_parms.static_ip** | true or false - use static IPs for agents using NMState | true
 **hypershift.agents_parms.static_ip_parms.ip** | List of IP addresses for agents | 192.168.10.1
 **hypershift.agents_parms.static_ip_parms.interface** | Interface for agents for configuring NMStateConfig | eth0
-**hypershift.agents_parms.static_ip_parms.generate_mac_addr** | true or false - randomly generate mac addresses for agents or manually specify them | true
 **hypershift.agents_parms.agents_count** | Number of agents for the hosted cluster <br /> The same number of compute nodes will be attached to Hosted Cotrol Plane | 2
 **hypershift.agents_parms.agent_mac_addr** | List of macaddresses for the agents. <br /> Configure in DHCP if you are using dynamic IPs for Agents. | - 52:54:00:ba:d3:f7 
 **hypershift.agents_parms.disk_size** | Disk size for agents | 100G

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -214,7 +214,7 @@
 **hypershift.hcp.pull_secret** | Pull Secret of Management Cluster <br /> Make sure to enclose pull_secret in 'single quotes' | '{"auths":{"cloud.openshift<br />.com":{"auth":"b3Blb<br />...<br />4yQQ==","email":"redhat.<br />user@gmail.com"}}}'
 **hypershift.mce.version** | version for multicluster-engine Operator | 2.4
 **hypershift.mce.instance_name** | name of the MultiClusterEngine instance | engine
-**hypershift.mce.delete_mce_while_deleting_resources** | true or false - deletes mce and related resources while running deletion playbook | true
+**hypershift.mce.delete** | true or false - deletes mce and related resources while running deletion playbook | true
 **hypershift.asc.url_for_ocp_release_file** | Add URL for OCP release.txt File | https://... <br /> ..../release.txt
 **hypershift.asc.db_volume_size** | DatabaseStorage Volume Size | 10Gi
 **hypershift.asc.fs_volume_size** | FileSystem Storage Volume Size | 10Gi

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -222,6 +222,7 @@
 **hypershift.agents_parms.static_ip_parms.static_ip** | true or false - set to true if you want to use static IPs for agents using NMState | true
 **hypershift.agents_parms.static_ip_parms.ip** | Give here list of IP addresses for agents | 192.168.10.1
 **hypershift.agents_parms.static_ip_parms.interface** | Interface for agents for configuring NMStateConfig | eth0
+**hypershift.agents_parms.static_ip_parms.generate_mac_addr** | true or false - set to false if you want to use a specific mac addresses for agents | true
 **hypershift.agents_parms.agents_count** | Number of agents for the hosted cluster <br /> The same number of compute nodes will be attached to Hosted Cotrol Plane | 2
 **hypershift.agents_parms.agent_mac_addr** | Give here list of macaddresses for the agents <br /> These mac addresses should be configured in DHCP if you are using dynamic IPs for Agents | [ 52:54:00:d9:5b:d9 , 52:54:00:ba:d3:f7 ]
 **hypershift.agents_parms.disk_size** | Disk size for agents | 100G

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -224,7 +224,7 @@
 **hypershift.agents_parms.static_ip_parms.interface** | Interface for agents for configuring NMStateConfig | eth0
 **hypershift.agents_parms.static_ip_parms.generate_mac_addr** | true or false - set to false if you want to use a specific mac addresses for agents in case of static IP configuration | true
 **hypershift.agents_parms.agents_count** | Number of agents for the hosted cluster <br /> The same number of compute nodes will be attached to Hosted Cotrol Plane | 2
-**hypershift.agents_parms.agent_mac_addr** | Give here list of macaddresses for the agents <br /> These mac addresses should be configured in DHCP if you are using dynamic IPs for Agents | - 52:54:00:ba:d3:f7 
+**hypershift.agents_parms.agent_mac_addr** | List of macaddresses for the agents. <br /> Configure in DHCP if you are using dynamic IPs for Agents. | - 52:54:00:ba:d3:f7 
 **hypershift.agents_parms.disk_size** | Disk size for agents | 100G
 **hypershift.agents_parms.ram** | RAM for agents | 16384
 **hypershift.agents_parms.vcpus** | vCPUs for agents | 4

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -212,6 +212,9 @@
 **hypershift.hcp.machine_cidr** | Machines CIDR for Hosted Cluster | 192.168.122.0/24
 **hypershift.hcp.arch** | Architecture for InfraEnv and AgentServiceConfig" | s390x
 **hypershift.hcp.pull_secret** | Pull Secret of Management Cluster <br /> Make sure to enclose pull_secret in 'single quotes' | '{"auths":{"cloud.openshift<br />.com":{"auth":"b3Blb<br />...<br />4yQQ==","email":"redhat.<br />user@gmail.com"}}}'
+**hypershift.mce.version** | version for multicluster-engine Operator | 2.4
+**hypershift.mce.instance_name** | name of the MultiClusterEngine instance | engine
+**hypershift.mce.delete_mce_while_deleting_resources** | true or false - deletes mce and related resources while running deletion playbook | true
 **hypershift.asc.url_for_ocp_release_file** | Add URL for OCP release.txt File | https://... <br /> ..../release.txt
 **hypershift.asc.db_volume_size** | DatabaseStorage Volume Size | 10Gi
 **hypershift.asc.fs_volume_size** | FileSystem Storage Volume Size | 10Gi

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -219,10 +219,10 @@
 **hypershift.asc.iso_url** | Give URL for ISO image | https://... <br /> ...s390x-live.s390x.iso
 **hypershift.asc.root_fs_url** | Give URL for rootfs image | https://... <br /> ... live-rootfs.s390x.img
 **hypershift.asc.mce_namespace** | Namespace where your Multicluster Engine Operator is installed. <br /> Recommended Namespace for MCE is 'multicluster-engine'. <br /> Change this only if MCE is installed in other namespace. | multicluster-engine
-**hypershift.agents_parms.static_ip_parms.static_ip** | true or false - set to true if you want to use static IPs for agents using NMState | true
-**hypershift.agents_parms.static_ip_parms.ip** | Give here list of IP addresses for agents | 192.168.10.1
+**hypershift.agents_parms.static_ip_parms.static_ip** | true or false - use static IPs for agents using NMState | true
+**hypershift.agents_parms.static_ip_parms.ip** | List of IP addresses for agents | 192.168.10.1
 **hypershift.agents_parms.static_ip_parms.interface** | Interface for agents for configuring NMStateConfig | eth0
-**hypershift.agents_parms.static_ip_parms.generate_mac_addr** | true or false - set to false if you want to use a specific mac addresses for agents in case of static IP configuration | true
+**hypershift.agents_parms.static_ip_parms.generate_mac_addr** | true or false - randomly generate mac addresses for agents or manually specify them | true
 **hypershift.agents_parms.agents_count** | Number of agents for the hosted cluster <br /> The same number of compute nodes will be attached to Hosted Cotrol Plane | 2
 **hypershift.agents_parms.agent_mac_addr** | List of macaddresses for the agents. <br /> Configure in DHCP if you are using dynamic IPs for Agents. | - 52:54:00:ba:d3:f7 
 **hypershift.agents_parms.disk_size** | Disk size for agents | 100G

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -190,7 +190,7 @@
 **hypershift.kvm_host_user** | User for KVM host | root
 **hypershift.bastion_hypershift** | IPv4 address for bastion of Hosted Cluster | 192.168.10.1
 **hypershift.bastion_hypershift_user** | User for bastion of Hosted Cluster | root
-**hypershift.create_bastion** | True or False - create bastion with the provided IP (hypershift.bastion_hypershift) | True
+**hypershift.create_bastion** | true or false - create bastion with the provided IP (hypershift.bastion_hypershift) | true
 **hypershift.networking_device** | The network interface card from Linux's perspective. <br /> Usually enc and then a number that comes from the dev_num of the network adapter. | enc1100
 **hypershift.gateway** | IPv4 Address for gateway from where the kvm_host and bastion are reachable  <br /> This for adding ip route from kvm_host to bastion through gateway  | 192.168.10.1
 **hypershift.branch_for_cli** | Git branch for latest release of hypershift | release-4.13
@@ -219,6 +219,9 @@
 **hypershift.asc.iso_url** | Give URL for ISO image | https://... <br /> ...s390x-live.s390x.iso
 **hypershift.asc.root_fs_url** | Give URL for rootfs image | https://... <br /> ... live-rootfs.s390x.img
 **hypershift.asc.mce_namespace** | Namespace where your Multicluster Engine Operator is installed. <br /> Recommended Namespace for MCE is 'multicluster-engine'. <br /> Change this only if MCE is installed in other namespace. | multicluster-engine
+**hypershift.agents_parms.static_ip_parms.static_ip** | true or false - set to true if you want to use static IPs for agents using NMState | true
+**hypershift.agents_parms.static_ip_parms.ip** | Give here list of IP addresses for agents | 192.168.10.1
+**hypershift.agents_parms.static_ip_parms.interface** | Interface for agents for configuring NMStateConfig | eth0
 **hypershift.agents_parms.agents_count** | Number of agents for the hosted cluster <br /> The same number of compute nodes will be attached to Hosted Cotrol Plane | 2
 **hypershift.agents_parms.agent_mac_addr** | Give here list of macaddresses for the agents <br /> These mac addresses should be configured in DHCP if you are using dynamic IPs for Agents | [ 52:54:00:d9:5b:d9 , 52:54:00:ba:d3:f7 ]
 **hypershift.agents_parms.disk_size** | Disk size for agents | 100G

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -222,7 +222,7 @@
 **hypershift.agents_parms.static_ip_parms.static_ip** | true or false - set to true if you want to use static IPs for agents using NMState | true
 **hypershift.agents_parms.static_ip_parms.ip** | Give here list of IP addresses for agents | 192.168.10.1
 **hypershift.agents_parms.static_ip_parms.interface** | Interface for agents for configuring NMStateConfig | eth0
-**hypershift.agents_parms.static_ip_parms.generate_mac_addr** | true or false - set to false if you want to use a specific mac addresses for agents | true
+**hypershift.agents_parms.static_ip_parms.generate_mac_addr** | true or false - set to false if you want to use a specific mac addresses for agents in case of static IP configuration | true
 **hypershift.agents_parms.agents_count** | Number of agents for the hosted cluster <br /> The same number of compute nodes will be attached to Hosted Cotrol Plane | 2
 **hypershift.agents_parms.agent_mac_addr** | Give here list of macaddresses for the agents <br /> These mac addresses should be configured in DHCP if you are using dynamic IPs for Agents | - 52:54:00:ba:d3:f7 
 **hypershift.agents_parms.disk_size** | Disk size for agents | 100G

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -279,7 +279,7 @@ hypershift:
     agents_count: 
     # Give the list of macaddress for agents here if you want to use specific mac addresses
     agent_mac_addr:  
-    - #
+      #- 
     disk_size: 100G
     ram: 16384
     vcpus: 4

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -270,9 +270,16 @@ hypershift:
     mce_namespace: "multicluster-engine" # This is the Recommended Namespace for Multicluster Engine operator
 
   agents_parms:
+    static_ip_parms:
+      static_ip: 'true' 
+      ip:     # Required only if static_ip is true
+      - #
+
+      interface: 'eth0'
+
     agents_count: 
     # Give the list of macaddress for agents here separated by ,
-    agent_mac_addr: [  ]
+    agent_mac_addr: [  ]   # Required only if static_ip is false
     disk_size: 100G
     ram: 16384
     vcpus: 4

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -261,7 +261,7 @@ hypershift:
   # MultiClusterEngine Parameters
   mce:
     version: 
-    instance_name: 'engine'
+    instance_name: engine
     delete_mce_while_deleting_resources: false
 
   # AgentServiceConfig Parameters

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -276,7 +276,6 @@ hypershift:
         #- 
         #- 
       interface: eth0
-      generate_mac_addr: true
     agents_count: 
     # Give the list of macaddress for agents here if you want to use specific mac addresses
     agent_mac_addr:  

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -273,7 +273,7 @@ hypershift:
     ocp_version:
     iso_url:
     root_fs_url:
-    mce_namespace: "multicluster-engine" # This is the Recommended Namespace for Multicluster Engine operator
+    mce_namespace: multicluster-engine # This is the Recommended Namespace for Multicluster Engine operator
 
   agents_parms:
     static_ip_parms:

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -258,6 +258,12 @@ hypershift:
     # Make sure to enclose pull_secret in 'single quotes'
     pull_secret:
 
+  # MultiClusterEngine Parameters
+  mce:
+    version: 
+    instance_name: 'engine'
+    delete_mce_while_deleting_resources: false
+
   # AgentServiceConfig Parameters
 
   asc:

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -271,12 +271,12 @@ hypershift:
 
   agents_parms:
     static_ip_parms:
-      static_ip: 'true' 
+      static_ip: true
       ip:     # Required only if static_ip is true
-      - #
-
-      interface: 'eth0'
-      generate_mac_addr: 'true'
+        #- 
+        #- 
+      interface: eth0
+      generate_mac_addr: true
     agents_count: 
     # Give the list of macaddress for agents here if you want to use specific mac addresses
     agent_mac_addr:  

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -225,7 +225,7 @@ hypershift:
   bastion_hypershift:
   bastion_hypershift_user:
 
-  create_bastion: 'true'
+  create_bastion: true
   networking_device: enc1100
 
   gateway: 

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -283,7 +283,7 @@ hypershift:
         #- 
       interface: eth0
     agents_count: 
-    # Give the list of macaddress for agents here if you want to use specific mac addresses
+    # If you want to use specific mac addresses, provide them here
     agent_mac_addr:  
       #- 
     disk_size: 100G

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -262,7 +262,7 @@ hypershift:
   mce:
     version: 
     instance_name: engine
-    delete_mce_while_deleting_resources: false
+    delete: false
 
   # AgentServiceConfig Parameters
 

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -276,10 +276,11 @@ hypershift:
       - #
 
       interface: 'eth0'
-
+      generate_mac_addr: 'true'
     agents_count: 
-    # Give the list of macaddress for agents here separated by ,
-    agent_mac_addr: [  ]   # Required only if static_ip is false
+    # Give the list of macaddress for agents here 
+    agent_mac_addr:  
+    - #
     disk_size: 100G
     ram: 16384
     vcpus: 4

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -278,7 +278,7 @@ hypershift:
       interface: 'eth0'
       generate_mac_addr: 'true'
     agents_count: 
-    # Give the list of macaddress for agents here 
+    # Give the list of macaddress for agents here if you want to use specific mac addresses
     agent_mac_addr:  
     - #
     disk_size: 100G

--- a/playbooks/create_hosted_cluster.yaml
+++ b/playbooks/create_hosted_cluster.yaml
@@ -30,7 +30,7 @@
     - name: Creating Bastion
       include_role:
         name: create_bastion_hypershift
-      when: hypershift.create_bastion == 'true'
+      when: hypershift.create_bastion == true
 
 - name: Configuring Bastion
   hosts: bastion_hypershift

--- a/playbooks/create_hosted_cluster.yaml
+++ b/playbooks/create_hosted_cluster.yaml
@@ -59,6 +59,7 @@
   vars_files:
     - "{{playbook_dir}}/secrets.yaml"
   roles:
+  - install_mce_operator
   - create_agentserviceconfig_hypershift
   - create_hcp_InfraEnv_hypershift
 

--- a/roles/boot_agents_hypershift/tasks/main.yaml
+++ b/roles/boot_agents_hypershift/tasks/main.yaml
@@ -12,7 +12,7 @@
     {% endif %}
 
     virt-install \
-    --name "{{ hypershift.hcp.hosted_cluster_name }}-agent-{{item}}" \
+    --name "{{ hypershift.hcp.hosted_cluster_name }}-agent-{{ item }}" \
     --autostart \
     --ram="{{ hypershift.agents_parms.ram }}" \
     --cpu host \

--- a/roles/boot_agents_hypershift/tasks/main.yaml
+++ b/roles/boot_agents_hypershift/tasks/main.yaml
@@ -5,7 +5,7 @@
 
 - name: Boot Agents
   shell: |
-    {% if hypershift.agents_parms.static_ip_parms.static_ip == 'true' %}
+    {% if hypershift.agents_parms.static_ip_parms.static_ip == true %}
     mac_address=$(oc get NmStateConfig static-ip-nmstate-config-{{ hypershift.hcp.hosted_cluster_name }}-{{ item }} -n {{ hypershift.hcp.clusters_namespace }}-{{ hypershift.hcp.hosted_cluster_name }} -o json | jq -r '.spec.interfaces[] | .macAddress')
     {% else %}
     mac_address="{{ hypershift.agents_parms.agent_mac_addr[item] }}"

--- a/roles/boot_agents_hypershift/tasks/main.yaml
+++ b/roles/boot_agents_hypershift/tasks/main.yaml
@@ -5,6 +5,12 @@
 
 - name: Boot Agents
   shell: |
+    {% if hypershift.agents_parms.static_ip_parms.static_ip == 'true' %}
+    mac_address=$(oc get NmStateConfig static-ip-nmstate-config-{{ hypershift.hcp.hosted_cluster_name }}-{{ item }} -n {{ hypershift.hcp.clusters_namespace }}-{{ hypershift.hcp.hosted_cluster_name }} -o json | jq -r '.spec.interfaces[] | .macAddress')
+    {% else %}
+    mac_address="{{ hypershift.agents_parms.agent_mac_addr[item] }}"
+    {% endif %}
+
     virt-install \
     --name "{{ hypershift.hcp.hosted_cluster_name }}-agent-{{item}}" \
     --autostart \
@@ -13,7 +19,7 @@
     --vcpus="{{ hypershift.agents_parms.vcpus }}"  \
     --location "/var/lib/libvirt/images/pxeboot/,kernel=kernel.img,initrd=initrd.img" \
     --disk /home/libvirt/images/{{ hypershift.hcp.hosted_cluster_name }}-agent{{ item }}.qcow2 \
-    --network network:{{ env.bridge_name }},mac={{ hypershift.agents_parms.agent_mac_addr[item] }} \
+    --network network:{{ env.bridge_name }},mac=$mac_address \
     --graphics none \
     --noautoconsole  \
     --wait=-1 \

--- a/roles/create_hcp_InfraEnv_hypershift/tasks/main.yaml
+++ b/roles/create_hcp_InfraEnv_hypershift/tasks/main.yaml
@@ -62,19 +62,36 @@
   retries: 30
   delay: 10
 
-- name: Create InfraEnv Resource
-  k8s:
-    namespace: "{{ hosted_control_plane_namespace }}"
-    definition:
-      apiVersion: agent-install.openshift.io/v1beta1
-      kind: InfraEnv
-      metadata:
-        name: "{{ hypershift.hcp.hosted_cluster_name }}"
-      spec:
-        cpuArchitecture: "{{ hypershift.hcp.arch }}"
-        pullSecretRef:
-          name: pull-secret
-        sshAuthorizedKey: "{{ ssh_key }}"
+- name: Create InfraEnv.yaml
+  template:
+    src: InfraEnv.yaml.j2
+    dest: /root/ansible_workdir/InfraEnv.yaml
+
+- name: Deploy InfraEnv Resource
+  command: oc apply -f /root/ansible_workdir/InfraEnv.yaml
+
+- name: Creating list of mac addresses
+  set_fact:
+    agent_mac_addr: []
+  when: hypershift.agents_parms.static_ip_parms.static_ip == 'true'
+
+- name: Generate mac addresses for agents
+  set_fact:
+    agent_mac_addr: "{{ agent_mac_addr +  ['52:54:00' | community.general.random_mac] }}"
+  when: hypershift.agents_parms.static_ip_parms.static_ip == 'true'
+  loop: "{{ range(hypershift.agents_parms.agents_count|int) | list }}"
+
+- name: Create NMState Configs
+  template:
+    src:  nmStateConfig.yaml.j2
+    dest: /root/ansible_workdir/nmStateConfig-agent-{{ item }}.yaml
+  when: hypershift.agents_parms.static_ip_parms.static_ip == 'true'
+  loop: "{{ range(hypershift.agents_parms.agents_count|int) | list }}"
+
+- name: Deploy NMState Configs
+  command: oc apply -f /root/ansible_workdir/nmStateConfig-agent-{{ item }}.yaml
+  when: hypershift.agents_parms.static_ip_parms.static_ip == 'true'
+  loop: "{{ range(hypershift.agents_parms.agents_count|int) | list }}"
 
 - name: Wait for ISO to generate in InfraEnv 
   shell: oc get InfraEnv -n  {{ hosted_control_plane_namespace }} --no-headers

--- a/roles/create_hcp_InfraEnv_hypershift/tasks/main.yaml
+++ b/roles/create_hcp_InfraEnv_hypershift/tasks/main.yaml
@@ -78,12 +78,12 @@
 - name: Getting mac addresss for agents
   set_fact:
     agent_mac_addr: "{{ hypershift.agents_parms.agent_mac_addr }}"
-  when: ( hypershift.agents_parms.static_ip_parms.static_ip == true ) and ( hypershift.agents_parms.static_ip_parms.generate_mac_addr == false )
+  when: ( hypershift.agents_parms.static_ip_parms.static_ip == true ) and ( hypershift.agents_parms.agent_mac_addr | length != 0 )
 
 - name: Generate mac addresses for agents
   set_fact:
     agent_mac_addr: "{{ agent_mac_addr +  ['52:54:00' | community.general.random_mac] }}"
-  when: ( hypershift.agents_parms.static_ip_parms.static_ip == true ) and ( hypershift.agents_parms.static_ip_parms.generate_mac_addr == true )
+  when: ( hypershift.agents_parms.static_ip_parms.static_ip == true ) and ( hypershift.agents_parms.agent_mac_addr | length == 0 )
   loop: "{{ range(hypershift.agents_parms.agents_count|int) | list }}"
 
 - name: Create NMState Configs

--- a/roles/create_hcp_InfraEnv_hypershift/tasks/main.yaml
+++ b/roles/create_hcp_InfraEnv_hypershift/tasks/main.yaml
@@ -73,29 +73,29 @@
 - name: Creating list of mac addresses
   set_fact:
     agent_mac_addr: []
-  when: hypershift.agents_parms.static_ip_parms.static_ip == 'true'
+  when: hypershift.agents_parms.static_ip_parms.static_ip == true
 
 - name: Getting mac addresss for agents
   set_fact:
     agent_mac_addr: "{{ hypershift.agents_parms.agent_mac_addr }}"
-  when: ( hypershift.agents_parms.static_ip_parms.static_ip == 'true' ) and ( hypershift.agents_parms.static_ip_parms.generate_mac_addr == 'false' )
+  when: ( hypershift.agents_parms.static_ip_parms.static_ip == true ) and ( hypershift.agents_parms.static_ip_parms.generate_mac_addr == false )
 
 - name: Generate mac addresses for agents
   set_fact:
     agent_mac_addr: "{{ agent_mac_addr +  ['52:54:00' | community.general.random_mac] }}"
-  when: ( hypershift.agents_parms.static_ip_parms.static_ip == 'true' ) and ( hypershift.agents_parms.static_ip_parms.generate_mac_addr == 'true' )
+  when: ( hypershift.agents_parms.static_ip_parms.static_ip == true ) and ( hypershift.agents_parms.static_ip_parms.generate_mac_addr == true )
   loop: "{{ range(hypershift.agents_parms.agents_count|int) | list }}"
 
 - name: Create NMState Configs
   template:
     src:  nmStateConfig.yaml.j2
     dest: /root/ansible_workdir/nmStateConfig-agent-{{ item }}.yaml
-  when: hypershift.agents_parms.static_ip_parms.static_ip == 'true'
+  when: hypershift.agents_parms.static_ip_parms.static_ip == true
   loop: "{{ range(hypershift.agents_parms.agents_count|int) | list }}"
 
 - name: Deploy NMState Configs
   command: oc apply -f /root/ansible_workdir/nmStateConfig-agent-{{ item }}.yaml
-  when: hypershift.agents_parms.static_ip_parms.static_ip == 'true'
+  when: hypershift.agents_parms.static_ip_parms.static_ip == true
   loop: "{{ range(hypershift.agents_parms.agents_count|int) | list }}"
 
 - name: Wait for ISO to generate in InfraEnv 

--- a/roles/create_hcp_InfraEnv_hypershift/tasks/main.yaml
+++ b/roles/create_hcp_InfraEnv_hypershift/tasks/main.yaml
@@ -78,12 +78,12 @@
 - name: Getting mac addresss for agents
   set_fact:
     agent_mac_addr: "{{ hypershift.agents_parms.agent_mac_addr }}"
-  when: ( hypershift.agents_parms.static_ip_parms.static_ip == true ) and ( hypershift.agents_parms.agent_mac_addr | length != 0 )
+  when: ( hypershift.agents_parms.static_ip_parms.static_ip == true ) and ( hypershift.agents_parms.agent_mac_addr != None )
 
 - name: Generate mac addresses for agents
   set_fact:
     agent_mac_addr: "{{ agent_mac_addr +  ['52:54:00' | community.general.random_mac] }}"
-  when: ( hypershift.agents_parms.static_ip_parms.static_ip == true ) and ( hypershift.agents_parms.agent_mac_addr | length == 0 )
+  when: ( hypershift.agents_parms.static_ip_parms.static_ip == true ) and ( hypershift.agents_parms.agent_mac_addr == None )
   loop: "{{ range(hypershift.agents_parms.agents_count|int) | list }}"
 
 - name: Create NMState Configs

--- a/roles/create_hcp_InfraEnv_hypershift/tasks/main.yaml
+++ b/roles/create_hcp_InfraEnv_hypershift/tasks/main.yaml
@@ -75,10 +75,15 @@
     agent_mac_addr: []
   when: hypershift.agents_parms.static_ip_parms.static_ip == 'true'
 
+- name: Getting mac addresss for agents
+  set_fact:
+    agent_mac_addr: "{{ hypershift.agents_parms.agent_mac_addr }}"
+  when: ( hypershift.agents_parms.static_ip_parms.static_ip == 'true' ) and ( hypershift.agents_parms.static_ip_parms.generate_mac_addr == 'false' )
+
 - name: Generate mac addresses for agents
   set_fact:
     agent_mac_addr: "{{ agent_mac_addr +  ['52:54:00' | community.general.random_mac] }}"
-  when: hypershift.agents_parms.static_ip_parms.static_ip == 'true'
+  when: ( hypershift.agents_parms.static_ip_parms.static_ip == 'true' ) and ( hypershift.agents_parms.static_ip_parms.generate_mac_addr == 'true' )
   loop: "{{ range(hypershift.agents_parms.agents_count|int) | list }}"
 
 - name: Create NMState Configs

--- a/roles/create_hcp_InfraEnv_hypershift/templates/InfraEnv.yaml.j2
+++ b/roles/create_hcp_InfraEnv_hypershift/templates/InfraEnv.yaml.j2
@@ -1,0 +1,15 @@
+apiVersion: agent-install.openshift.io/v1beta1
+kind: InfraEnv
+metadata:
+  name: "{{ hypershift.hcp.hosted_cluster_name }}"
+  namespace: "{{ hypershift.hcp.clusters_namespace }}-{{ hypershift.hcp.hosted_cluster_name }}"
+spec:
+{% if hypershift.agents_parms.static_ip_parms.static_ip == 'true' %}
+  nmStateConfigLabelSelector:
+    matchLabels:
+      infraenv: "static-ip-{{ hypershift.hcp.hosted_cluster_name }}"
+{% endif %}
+  cpuArchitecture: "{{ hypershift.hcp.arch }}"
+  pullSecretRef:
+    name: pull-secret
+  sshAuthorizedKey: "{{ ssh_key }}"

--- a/roles/create_hcp_InfraEnv_hypershift/templates/InfraEnv.yaml.j2
+++ b/roles/create_hcp_InfraEnv_hypershift/templates/InfraEnv.yaml.j2
@@ -4,7 +4,7 @@ metadata:
   name: "{{ hypershift.hcp.hosted_cluster_name }}"
   namespace: "{{ hypershift.hcp.clusters_namespace }}-{{ hypershift.hcp.hosted_cluster_name }}"
 spec:
-{% if hypershift.agents_parms.static_ip_parms.static_ip == 'true' %}
+{% if hypershift.agents_parms.static_ip_parms.static_ip == true %}
   nmStateConfigLabelSelector:
     matchLabels:
       infraenv: "static-ip-{{ hypershift.hcp.hosted_cluster_name }}"

--- a/roles/create_hcp_InfraEnv_hypershift/templates/nmStateConfig.yaml.j2
+++ b/roles/create_hcp_InfraEnv_hypershift/templates/nmStateConfig.yaml.j2
@@ -1,0 +1,34 @@
+apiVersion: agent-install.openshift.io/v1beta1
+kind: NMStateConfig
+metadata:
+  name: "static-ip-nmstate-config-{{ hypershift.hcp.hosted_cluster_name }}-{{ item }}"
+  namespace: "{{ hypershift.hcp.clusters_namespace }}-{{ hypershift.hcp.hosted_cluster_name }}"
+  labels:
+    infraenv: "static-ip-{{ hypershift.hcp.hosted_cluster_name }}"
+spec:
+  config:
+    interfaces:
+      - name: "{{ hypershift.agents_parms.static_ip_parms.interface }}"
+        type: ethernet
+        state: up
+        mac-address: "{{ agent_mac_addr[item] }}"
+        ipv4:
+          enabled: true
+          address:
+            - ip: "{{ hypershift.agents_parms.static_ip_parms.ip[item] }}"
+              prefix-length: 16
+          dhcp: false
+    routes:
+      config:
+        - destination: 0.0.0.0/0
+          next-hop-address: "{{ hypershift.gateway }}"
+          next-hop-interface: "{{ hypershift.agents_parms.static_ip_parms.interface }}"
+          table-id: 254
+    dns-resolver:
+      config:
+        server:
+          - "{{ hypershift.agents_parms.nameserver }}"
+
+  interfaces:
+    - name: "{{ hypershift.agents_parms.static_ip_parms.interface }}"
+      macAddress: "{{ agent_mac_addr[item] }}"

--- a/roles/delete_resources_bastion_hypershift/tasks/main.yaml
+++ b/roles/delete_resources_bastion_hypershift/tasks/main.yaml
@@ -80,27 +80,27 @@
     kind: AgentServiceConfig
     name: agent
     state: absent
-  when: hypershift.mce.delete_mce_while_deleting_resources == true
+  when: hypershift.mce.delete == true
 
 - name: Delete Provisioning
   command: oc delete Provisioning provisioning-configuration
-  when: hypershift.mce.delete_mce_while_deleting_resources == true
+  when: hypershift.mce.delete == true
 
 - name: Delete ClusterImageSet
   command: oc delete ClusterImageSet img{{ hypershift.hcp.ocp_release }}-appsub
-  when: hypershift.mce.delete_mce_while_deleting_resources == true
+  when: hypershift.mce.delete == true
 
 - name: Delete MCE Instance
   command: oc delete mce {{ hypershift.mce.instance_name }}
-  when: hypershift.mce.delete_mce_while_deleting_resources == true
+  when: hypershift.mce.delete == true
 
 - name: Delete MCE Subscription
   command: oc delete Subscription multicluster-engine -n {{ hypershift.asc.mce_namespace }}
-  when: hypershift.mce.delete_mce_while_deleting_resources == true
+  when: hypershift.mce.delete == true
 
 - name: Delete Operator Group - MCE 
   command: oc delete OperatorGroup multicluster-engine -n {{ hypershift.asc.mce_namespace }}
-  when: hypershift.mce.delete_mce_while_deleting_resources == true
+  when: hypershift.mce.delete == true
 
 - name: Delete MCE Namespace
   k8s:
@@ -108,4 +108,4 @@
     kind: Namespace
     name: "{{ hypershift.asc.mce_namespace }}"
     state: absent
-  when: hypershift.mce.delete_mce_while_deleting_resources == true
+  when: hypershift.mce.delete == true

--- a/roles/delete_resources_bastion_hypershift/tasks/main.yaml
+++ b/roles/delete_resources_bastion_hypershift/tasks/main.yaml
@@ -83,23 +83,48 @@
   when: hypershift.mce.delete == true
 
 - name: Delete Provisioning
-  command: oc delete Provisioning provisioning-configuration
+  k8s:
+    name: provisioning-configuration
+    api_version: metal3.io/v1alpha1
+    kind: Provisioning
+    state: absent 
   when: hypershift.mce.delete == true
 
 - name: Delete ClusterImageSet
-  command: oc delete ClusterImageSet img{{ hypershift.hcp.ocp_release }}-appsub
+  k8s:
+    name: "img{{ hypershift.hcp.ocp_release }}-appsub"
+    api_version: hive.openshift.io/v1
+    kind: ClusterImageSet
+    state: absent
   when: hypershift.mce.delete == true
 
 - name: Delete MCE Instance
-  command: oc delete mce {{ hypershift.mce.instance_name }}
+  k8s:
+    name: "{{ hypershift.mce.instance_name }}"
+    namespace: "{{ hypershift.asc.mce_namespace }}"
+    api_version: multicluster.openshift.io/v1
+    kind: MultiClusterEngine
+    state: absent
+    wait: yes
+    wait_timeout: 400
   when: hypershift.mce.delete == true
 
 - name: Delete MCE Subscription
-  command: oc delete Subscription multicluster-engine -n {{ hypershift.asc.mce_namespace }}
+  k8s:
+    name: multicluster-engine
+    namespace: "{{ hypershift.asc.mce_namespace }}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    state: absent
   when: hypershift.mce.delete == true
 
 - name: Delete Operator Group - MCE 
-  command: oc delete OperatorGroup multicluster-engine -n {{ hypershift.asc.mce_namespace }}
+  k8s:
+    name: multicluster-engine
+    namespace: "{{ hypershift.asc.mce_namespace }}"
+    api_version: operators.coreos.com/v1
+    kind: OperatorGroup
+    state: absent
   when: hypershift.mce.delete == true
 
 - name: Delete MCE Namespace

--- a/roles/delete_resources_bastion_hypershift/tasks/main.yaml
+++ b/roles/delete_resources_bastion_hypershift/tasks/main.yaml
@@ -80,3 +80,32 @@
     kind: AgentServiceConfig
     name: agent
     state: absent
+  when: hypershift.mce.delete_mce_while_deleting_resources == true
+
+- name: Delete Provisioning
+  command: oc delete Provisioning provisioning-configuration
+  when: hypershift.mce.delete_mce_while_deleting_resources == true
+
+- name: Delete ClusterImageSet
+  command: oc delete ClusterImageSet img{{ hypershift.hcp.ocp_release }}-appsub
+  when: hypershift.mce.delete_mce_while_deleting_resources == true
+
+- name: Delete MCE Instance
+  command: oc delete mce {{ hypershift.mce.instance_name }}
+  when: hypershift.mce.delete_mce_while_deleting_resources == true
+
+- name: Delete MCE Subscription
+  command: oc delete Subscription multicluster-engine -n {{ hypershift.asc.mce_namespace }}
+  when: hypershift.mce.delete_mce_while_deleting_resources == true
+
+- name: Delete Operator Group - MCE 
+  command: oc delete OperatorGroup multicluster-engine -n {{ hypershift.asc.mce_namespace }}
+  when: hypershift.mce.delete_mce_while_deleting_resources == true
+
+- name: Delete MCE Namespace
+  k8s:
+    api_version: v1
+    kind: Namespace
+    name: "{{ hypershift.asc.mce_namespace }}"
+    state: absent
+  when: hypershift.mce.delete_mce_while_deleting_resources == true

--- a/roles/install_mce_operator/tasks/main.yaml
+++ b/roles/install_mce_operator/tasks/main.yaml
@@ -1,0 +1,80 @@
+---
+- name: Check if multicluster-engine Namespace exists 
+  k8s_info:
+    api_version: v1
+    kind: Namespace
+    name: "{{ hypershift.asc.mce_namespace }}"
+  register: namespace_check
+  ignore_errors: yes
+
+- name: Create multicluster-engine  Namespace 
+  k8s:
+    api_version: v1
+    kind: Namespace
+    name: "{{ hypershift.asc.mce_namespace }}"
+    state: present
+  when: namespace_check.resources | length == 0 
+
+- name: Create OperatorGroup.yaml
+  template: 
+    src: OperatorGroup.yaml.j2
+    dest: /root/ansible_workdir/OperatorGroup.yaml
+
+- name: Deploy OperatorGroup
+  command: oc apply -f /root/ansible_workdir/OperatorGroup.yaml
+
+- name: Create Subscription.yaml
+  template:
+    src: Subscription.yaml.j2
+    dest: /root/ansible_workdir/Subscription.yaml
+
+- name: Deploy Subscription for MCE
+  command: oc apply -f /root/ansible_workdir/Subscription.yaml
+
+- name: Wait for MCE deployment to be created
+  shell: oc get all -n {{ hypershift.asc.mce_namespace }} | grep -i  deployment | grep -i multicluster-engine | wc -l
+  register: mce_deploy
+  until: mce_deploy.stdout == '1'
+  retries: 20
+  delay: 5
+
+- name: Wait for MCE deployment to be available
+  shell: oc get deployment multicluster-engine-operator -n {{ hypershift.asc.mce_namespace }} -o=jsonpath='{.status.replicas}{" "}{.status.availableReplicas}'
+  register: mce_pod_status
+  until: mce_pod_status.stdout.split(' ')[0] == mce_pod_status.stdout.split(' ')[1]
+  retries: 20
+  delay: 5
+
+- name: Create MultiClusterEngine.yaml
+  template:
+    src: MultiClusterEngine.yaml.j2
+    dest: /root/ansible_workdir/MultiClusterEngine.yaml
+
+- name: Deploy MCE Instance
+  command: oc apply -f /root/ansible_workdir/MultiClusterEngine.yaml
+
+- name: Wait for MCE to be Available
+  shell: oc get mce --no-headers | awk  '{print $2}' 
+  register: mce_status
+  until: mce_status.stdout == "Available"
+  retries: 40
+  delay: 10 
+
+- name: Enable hypershift-preview component in MCE
+  command: oc patch mce {{ hypershift.mce.instance_name }} -p '{"spec":{"overrides":{"components":[{"name":"hypershift-preview","enabled":true}]}}}' --type merge
+
+- name: Create ClusterImageSet.yaml
+  template:
+    src: ClusterImageSet.yaml.j2
+    dest: /root/ansible_workdir/ClusterImageSet.yaml
+
+- name: Deploy ClusterImageSet 
+  command: oc apply -f /root/ansible_workdir/ClusterImageSet.yaml
+
+- name: Create Provisioning.yaml
+  template:
+    src: Provisioning.yaml.j2
+    dest: /root/ansible_workdir/Provisioning.yaml
+
+- name: Deploy Provisioning 
+  command: oc apply -f /root/ansible_workdir/Provisioning.yaml

--- a/roles/install_mce_operator/templates/ClusterImageSet.yaml.j2
+++ b/roles/install_mce_operator/templates/ClusterImageSet.yaml.j2
@@ -1,0 +1,6 @@
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  name: img{{ hypershift.hcp.ocp_release }}-appsub
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:{{ hypershift.hcp.ocp_release }}

--- a/roles/install_mce_operator/templates/MultiClusterEngine.yaml.j2
+++ b/roles/install_mce_operator/templates/MultiClusterEngine.yaml.j2
@@ -1,0 +1,6 @@
+apiVersion: multicluster.openshift.io/v1
+kind: MultiClusterEngine
+metadata:
+  name: {{ hypershift.mce.instance_name }}
+  namespace: "{{ hypershift.asc.mce_namespace }}"
+spec: {}

--- a/roles/install_mce_operator/templates/OperatorGroup.yaml.j2
+++ b/roles/install_mce_operator/templates/OperatorGroup.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: multicluster-engine
+  namespace: "{{ hypershift.asc.mce_namespace }}"
+spec:
+  targetNamespaces:
+  - "{{ hypershift.asc.mce_namespace }}"

--- a/roles/install_mce_operator/templates/Provisioning.yaml.j2
+++ b/roles/install_mce_operator/templates/Provisioning.yaml.j2
@@ -1,0 +1,7 @@
+apiVersion: metal3.io/v1alpha1
+kind: Provisioning
+metadata:
+  name: provisioning-configuration
+spec:
+  provisioningNetwork: Disabled
+  watchAllNamespaces: true

--- a/roles/install_mce_operator/templates/Subscription.yaml.j2
+++ b/roles/install_mce_operator/templates/Subscription.yaml.j2
@@ -1,0 +1,12 @@
+piVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: multicluster-engine
+  namespace: "{{ hypershift.asc.mce_namespace }}"
+spec:
+  sourceNamespace: openshift-marketplace
+  source: redhat-operators
+  channel: stable-{{ hypershift.mce.version }}
+  installPlanApproval: Automatic
+  name: multicluster-engine
+

--- a/roles/install_mce_operator/templates/Subscription.yaml.j2
+++ b/roles/install_mce_operator/templates/Subscription.yaml.j2
@@ -1,4 +1,4 @@
-piVersion: operators.coreos.com/v1alpha1
+apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: multicluster-engine

--- a/roles/install_mce_operator/templates/Subscription.yaml.j2
+++ b/roles/install_mce_operator/templates/Subscription.yaml.j2
@@ -9,4 +9,3 @@ spec:
   channel: stable-{{ hypershift.mce.version }}
   installPlanApproval: Automatic
   name: multicluster-engine
-


### PR DESCRIPTION
Added  changes required for supporting Static IP configuration

- Adds labels to InfraEnv 
- Deploy NMStateConfig resources for Static IP configuration

Updated documentation for the same 