### PR TITLE
docs: automate docs deployment on update

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,31 @@
+name: Publish docs via GitHub Pages
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'mkdocs.yaml'
+      - 'docs/**'
+
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install mkdocs
+        run: pip install mkdocs
+
+      - name: Deploy docs
+        run: python3 -m mkdocs gh-deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a new workflow to GitHub Actions.

The action deploys an updated version of the documentation to GitHub Pages.

It is triggered when changes are pushed to 'mkdocs.yaml' or anything under the 'docs' folder on the 'main' branch.

This is necessary to make the docs up-to-date with our code, without manual intervention.

Tested on my fork, although it required some tweaking there to adjust it for testing purposes, so it might take some troubleshooting here in the upstream.