### PR TITLE
fix: pull updated gh-pages

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,11 +16,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
+
+    - name: Fetch Latest gh-pages Branch
+      run: |
+        git fetch origin gh-pages
+        git checkout gh-pages
+        git pull origin gh-pages
+        git checkout main
 
       - name: Install mkdocs
         run: pip install mkdocs


### PR DESCRIPTION
Hotfix to #196 that automates GitHub Pages deployments. Looks like the workflow failed in error because it didn't have the most recent version of the gh-pages branch. This PR will hopefully fix that issue.