### PR TITLE
fix: Temporary ignore some DNS checks

### DIFF
--- a/roles/check_dns/tasks/main.yaml
+++ b/roles/check_dns/tasks/main.yaml
@@ -5,6 +5,8 @@
   shell: "dig +short {{ env.bastion.networking.hostname }}.{{ env.bastion.networking.base_domain }} | tail -n1"
   register: bastion_lookup
   failed_when: env.bastion.networking.ip != bastion_lookup.stdout
+  # Ignore error, because of issue #166, #182
+  ignore_errors: true
 
 - name: Check internal cluster DNS resolution for external API and apps services
   tags: check_dns, dns
@@ -27,6 +29,8 @@
   shell: "dig +short {{ env.cluster.nodes.bootstrap.hostname }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }} | tail -n1"
   register: bootstrap_lookup
   failed_when: env.cluster.nodes.bootstrap.ip != bootstrap_lookup.stdout
+  # Ignore error, because of issue #166, #182
+  ignore_errors: true
 
 - name: Print results from bootstrap lookup
   tags: check_dns, dns
@@ -42,6 +46,7 @@
   loop_control:
     extended: yes
     index_var: i
+  ignore_errors: true
 
 - name: Check compute nodes DNS resolution
   tags: check_dns, dns


### PR DESCRIPTION
There are several open issues related to DNS. DNS setup needs to be verified. We ignore some DNS check results for now, because of issue 166, 182.