### PR TITLE
fix: Temporary ignore some DNS checks

### DIFF
--- a/playbooks/5_setup_bastion.yaml
+++ b/playbooks/5_setup_bastion.yaml
@@ -76,7 +76,7 @@
     - ssh_ocp_key_gen
     - set_firewall
     - { role: dns, when: env.bastion.options.dns }
-    - check_dns
+    - { role: check_dns, when env.bastion.options.dns is defined and env.bastion.options.dns }
     - { role: haproxy, when: env.bastion.options.loadbalancer.on_bastion }
     - httpd
 


### PR DESCRIPTION
There are several open issues related to DNS. DNS setup needs to be verified. We ignore some DNS check results for now, because of issue 166, 182.