### PR TITLE
feat: Add support for ARM KVM server

### DIFF
--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -61,6 +61,7 @@
 **env.bastion.resources.ram** | How much memory would you like to allocate the bastion (in<br /> megabytes)? Recommended 4096 or more | 4096
 **env.bastion.resources.swap** | How much swap storage would you like to allocate the bastion (in<br /> megabytes)? Recommended 4096 or more. | 4096
 **env.bastion.resources.vcpu** | How many virtual CPUs would you like to allocate to the bastion? Recommended 4 or more. | 4
+**env.bastion.resources.vcpu_model_option** | (Optional) Configure the CPU model and CPU features exposed to the guest | --cpu host
 **env.bastion.networking.ip** | IPv4 address for the bastion. | 192.168.10.3
 **env.bastion.networking.ipv6** | IPv6 address for the bastion if use_ipv6 variable is 'True'. | fd00::3
 **env.bastion.networking.hostname** | Hostname of the bastion. Will be combined with<br /> env.bastion.networking.base_domain to create a Fully Qualified Domain Name (FQDN). | ocpz-bastion
@@ -99,6 +100,7 @@
 **env.cluster.nodes.bootstrap.disk_size** | How much disk space do you want to allocate to the bootstrap node (in Gigabytes)? Bootstrap node<br /> is temporary and will be brought down automatically when its job completes. 120 or more recommended. | 120
 **env.cluster.nodes.bootstrap.ram** | How much memory would you like to allocate to the temporary bootstrap node (in<br /> megabytes)? Recommended 16384 or more. | 16384
 **env.cluster.nodes.bootstrap.vcpu** | How many virtual CPUs would you like to allocate to the temporary bootstrap node?<br /> Recommended 4 or more. | 4
+**env.cluster.nodes.bootstrap.vcpu_model_option** | (Optional) Configure the CPU model and CPU features exposed to the guest | --cpu host
 **env.cluster.nodes.bootstrap.vm_name** | Name of the temporary bootstrap node VM. Arbitrary value. | bootstrap
 **env.cluster.nodes.bootstrap.ip** | IPv4 address of the temporary bootstrap node. | 192.168.10.4
 **env.cluster.nodes.bootstrap.ipv6** | IPv6 address for the bootstrap if use_ipv6 variable is 'True'. | fd00::4
@@ -110,6 +112,7 @@
 **env.cluster.nodes.control.disk_size** | How much disk space do you want to allocate to each control node (in Gigabytes)? 120 or more recommended. | 120
 **env.cluster.nodes.control.ram** | How much memory would you like to allocate to the each control<br /> node (in megabytes)? Recommended 16384 or more. | 16384
 **env.cluster.nodes.control.vcpu** | How many virtual CPUs would you like to allocate to each control node? Recommended 4 or more. | 4
+**env.cluster.nodes.control.vcpu_model_option** | (Optional) Configure the CPU model and CPU features exposed to the guest | --cpu host
 **env.cluster.nodes.control.vm_name** | Name of the control node VMs. Arbitrary values. Usually no more or less than 3 are used. Must match<br /> the total number of IP addresses and hostnames for control nodes. Use provided list format. | control-1<br />control-2<br />control-3
 **env.cluster.nodes.control.ip** | IPv4 address of the control nodes. Use provided<br /> list formatting. | 192.168.10.5<br />192.168.10.6<br />192.168.10.7
 **env.cluster.nodes.control.ipv6** | IPv6 address for the control nodes. Use iprovided<br /> list formatting (if use_ipv6 variable is 'True'). | fd00::5<br />fd00::6<br />fd00::7
@@ -121,6 +124,7 @@
 **env.cluster.nodes.compute.disk_size** | How much disk space do you want to allocate to each compute<br /> node (in Gigabytes)? 120 or more recommended. | 120
 **env.cluster.nodes.compute.ram** | How much memory would you like to allocate to the each compute<br /> node (in megabytes)? Recommended 16384 or more. | 16384
 **env.cluster.nodes.compute.vcpu** | How many virtual CPUs would you like to allocate to each compute node? Recommended 2 or more. | 2
+**env.cluster.nodes.compute.vcpu_model_option** | (Optional) Configure the CPU model and CPU features exposed to the guest | --cpu host
 **env.cluster.nodes.compute.vm_name** | Name of the compute node VMs. Arbitrary values. This list can be expanded to any<br /> number of nodes, minimum 2. Must match the total number of IP<br /> addresses and hostnames for compute nodes. Use provided list format. | compute-1<br />compute-2
 **env.cluster.nodes.compute.ip** | IPv4 address of the compute nodes. Must match the total number of VM names and<br /> hostnames for compute nodes. Use provided list formatting. | 192.168.10.8<br />192.168.10.9
 **env.cluster.nodes.control.ipv6** | IPv6 address for the compute nodes. Use iprovided<br /> list formatting (if use_ipv6 variable is 'True'). | fd00::8<br />fd00::9
@@ -132,6 +136,7 @@
 **env.cluster.nodes.infra.disk_size** | <b>(Optional)</b> Set up compute nodes that are made for infrastructure workloads (ingress,<br /> monitoring, logging)? How much disk space do you want to allocate to each infra node (in Gigabytes)?<br /> 120 or more recommended. | 120
 **env.cluster.nodes.infra.ram** | <b>(Optional)</b> How much memory would you like to allocate to the each infra node (in<br /> megabytes)? Recommended 16384 or more. | 16384
 **env.cluster.nodes.infra.vcpu** | <b>(Optional)</b> How many virtual CPUs would you like to allocate to each infra node?<br /> Recommended 2 or more. | 2
+**env.cluster.nodes.infra.vcpu_model_option** | <b>(Optional)</b> Configure the CPU model and CPU features exposed to the guest | --cpu host
 **env.cluster.nodes.infra.vm_name** | <b>(Optional)</b> Name of additional infra node VMs. Arbitrary values. This list can be<br /> expanded to any number of nodes, minimum 2. Must match the total<br /> number of IP addresses and hostnames for infra nodes. Use provided list format. | infra-1<br />infra-2
 **env.cluster.nodes.infra.ip** | <b>(Optional)</b> IPv4 address of the infra nodes. This list can be expanded to any number of nodes,<br /> minimum 2. Use provided list formatting. | 192.168.10.10<br />192.168.10.11
 **env.cluster.nodes.infra.ipv6** | <b>(Optional)</b> IPv6 address of the infra nodes. iThis list can be expanded to any number of nodes,<br /> minimum 2. Use provided list formatting (if use_ipv6 variable is 'True'). | fd00::10<br />fd00::11

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -61,7 +61,7 @@
 **env.bastion.resources.ram** | How much memory would you like to allocate the bastion (in<br /> megabytes)? Recommended 4096 or more | 4096
 **env.bastion.resources.swap** | How much swap storage would you like to allocate the bastion (in<br /> megabytes)? Recommended 4096 or more. | 4096
 **env.bastion.resources.vcpu** | How many virtual CPUs would you like to allocate to the bastion? Recommended 4 or more. | 4
-**env.bastion.resources.vcpu_model_option** | (Optional) Configure the CPU model and CPU features exposed to the guest | --cpu host
+**env.bastion.resources.vcpu_model_option** | Configure the CPU model and CPU features exposed to the guest | --cpu host
 **env.bastion.networking.ip** | IPv4 address for the bastion. | 192.168.10.3
 **env.bastion.networking.ipv6** | IPv6 address for the bastion if use_ipv6 variable is 'True'. | fd00::3
 **env.bastion.networking.hostname** | Hostname of the bastion. Will be combined with<br /> env.bastion.networking.base_domain to create a Fully Qualified Domain Name (FQDN). | ocpz-bastion
@@ -100,7 +100,7 @@
 **env.cluster.nodes.bootstrap.disk_size** | How much disk space do you want to allocate to the bootstrap node (in Gigabytes)? Bootstrap node<br /> is temporary and will be brought down automatically when its job completes. 120 or more recommended. | 120
 **env.cluster.nodes.bootstrap.ram** | How much memory would you like to allocate to the temporary bootstrap node (in<br /> megabytes)? Recommended 16384 or more. | 16384
 **env.cluster.nodes.bootstrap.vcpu** | How many virtual CPUs would you like to allocate to the temporary bootstrap node?<br /> Recommended 4 or more. | 4
-**env.cluster.nodes.bootstrap.vcpu_model_option** | (Optional) Configure the CPU model and CPU features exposed to the guest | --cpu host
+**env.cluster.nodes.bootstrap.vcpu_model_option** | Configure the CPU model and CPU features exposed to the guest | --cpu host
 **env.cluster.nodes.bootstrap.vm_name** | Name of the temporary bootstrap node VM. Arbitrary value. | bootstrap
 **env.cluster.nodes.bootstrap.ip** | IPv4 address of the temporary bootstrap node. | 192.168.10.4
 **env.cluster.nodes.bootstrap.ipv6** | IPv6 address for the bootstrap if use_ipv6 variable is 'True'. | fd00::4
@@ -112,7 +112,7 @@
 **env.cluster.nodes.control.disk_size** | How much disk space do you want to allocate to each control node (in Gigabytes)? 120 or more recommended. | 120
 **env.cluster.nodes.control.ram** | How much memory would you like to allocate to the each control<br /> node (in megabytes)? Recommended 16384 or more. | 16384
 **env.cluster.nodes.control.vcpu** | How many virtual CPUs would you like to allocate to each control node? Recommended 4 or more. | 4
-**env.cluster.nodes.control.vcpu_model_option** | (Optional) Configure the CPU model and CPU features exposed to the guest | --cpu host
+**env.cluster.nodes.control.vcpu_model_option** | Configure the CPU model and CPU features exposed to the guest | --cpu host
 **env.cluster.nodes.control.vm_name** | Name of the control node VMs. Arbitrary values. Usually no more or less than 3 are used. Must match<br /> the total number of IP addresses and hostnames for control nodes. Use provided list format. | control-1<br />control-2<br />control-3
 **env.cluster.nodes.control.ip** | IPv4 address of the control nodes. Use provided<br /> list formatting. | 192.168.10.5<br />192.168.10.6<br />192.168.10.7
 **env.cluster.nodes.control.ipv6** | IPv6 address for the control nodes. Use iprovided<br /> list formatting (if use_ipv6 variable is 'True'). | fd00::5<br />fd00::6<br />fd00::7
@@ -124,7 +124,7 @@
 **env.cluster.nodes.compute.disk_size** | How much disk space do you want to allocate to each compute<br /> node (in Gigabytes)? 120 or more recommended. | 120
 **env.cluster.nodes.compute.ram** | How much memory would you like to allocate to the each compute<br /> node (in megabytes)? Recommended 16384 or more. | 16384
 **env.cluster.nodes.compute.vcpu** | How many virtual CPUs would you like to allocate to each compute node? Recommended 2 or more. | 2
-**env.cluster.nodes.compute.vcpu_model_option** | (Optional) Configure the CPU model and CPU features exposed to the guest | --cpu host
+**env.cluster.nodes.compute.vcpu_model_option** | Configure the CPU model and CPU features exposed to the guest | --cpu host
 **env.cluster.nodes.compute.vm_name** | Name of the compute node VMs. Arbitrary values. This list can be expanded to any<br /> number of nodes, minimum 2. Must match the total number of IP<br /> addresses and hostnames for compute nodes. Use provided list format. | compute-1<br />compute-2
 **env.cluster.nodes.compute.ip** | IPv4 address of the compute nodes. Must match the total number of VM names and<br /> hostnames for compute nodes. Use provided list formatting. | 192.168.10.8<br />192.168.10.9
 **env.cluster.nodes.control.ipv6** | IPv6 address for the compute nodes. Use iprovided<br /> list formatting (if use_ipv6 variable is 'True'). | fd00::8<br />fd00::9

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -156,7 +156,7 @@
 **env.install_config.api_version** | Kubernetes API version for the cluster. These install_config variables will be passed to the OCP<br /> install_config file. This file is templated in the get_ocp role during the setup_bastion playbook.<br /> To make more fine-tuned adjustments to the install_config, you can find it at<br /> roles/get_ocp/templates/install-config.yaml.j2 | v1
 **env.install_config.compute.architecture** | Computing architecture for the compute nodes. Must be s390x for clusters on IBM zSystems. | s390x
 **env.install_config.compute.hyperthreading** | Enable or disable hyperthreading on compute nodes. Recommended enabled. | Enabled
-**env.install_config.control.architecture** | Computing architecture for the control nodes. Must be s390x for clusters on IBM zSystems. | s390x
+**env.install_config.control.architecture** | Computing architecture for the control nodes. Must be s390x for clusters on IBM zSystems, amd64 for Intel or AMD systems, and arm64 for ARM servers. | s390x
 **env.install_config.control.hyperthreading** | Enable or disable hyperthreading on control nodes. Recommended enabled. | Enabled
 **env.install_config.cluster_network.cidr** | IPv4 block in Internal cluster networking in Classless Inter-Domain<br /> Routing (CIDR) notation. Recommended to keep as is. | 10.128.0.0/14
 **env.install_config.cluster_network.host_prefix** | The subnet prefix length to assign to each individual node. For example, if<br /> hostPrefix is set to 23 then each node is assigned a /23 subnet out of the given cidr. A hostPrefix<br /> value of 23 provides 510 (2^(32 - 23) - 2) pod IP addresses. | 23

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -58,6 +58,7 @@ env:
       ram: 4096
       swap: 4096
       vcpu: 4
+      vcpu_option: "--cpu host"
     networking:
       ip: #X
       ipv6: #X
@@ -102,6 +103,7 @@ env:
         disk_size: 120
         ram: 16384
         vcpu: 4
+        vcpu_option: "--cpu host"
         vm_name: #X
         ip: #X
         ipv6: #X
@@ -112,6 +114,7 @@ env:
         disk_size: 120
         ram: 16384
         vcpu: 4
+        vcpu_option: "--cpu host"
         vm_name:
           - #X
           - #X
@@ -134,6 +137,7 @@ env:
         disk_size: 120
         ram: 16384
         vcpu: 4
+        vcpu_option: "--cpu host"
         vm_name:
           - #X
           - #X

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -58,7 +58,7 @@ env:
       ram: 4096
       swap: 4096
       vcpu: 4
-      vcpu_option: "--cpu host"
+      vcpu_model_option: "--cpu host"
     networking:
       ip: #X
       ipv6: #X
@@ -103,7 +103,7 @@ env:
         disk_size: 120
         ram: 16384
         vcpu: 4
-        vcpu_option: "--cpu host"
+        vcpu_model_option: "--cpu host"
         vm_name: #X
         ip: #X
         ipv6: #X
@@ -114,7 +114,7 @@ env:
         disk_size: 120
         ram: 16384
         vcpu: 4
-        vcpu_option: "--cpu host"
+        vcpu_model_option: "--cpu host"
         vm_name:
           - #X
           - #X
@@ -137,7 +137,7 @@ env:
         disk_size: 120
         ram: 16384
         vcpu: 4
-        vcpu_option: "--cpu host"
+        vcpu_model_option: "--cpu host"
         vm_name:
           - #X
           - #X

--- a/roles/create_bastion/tasks/main.yaml
+++ b/roles/create_bastion/tasks/main.yaml
@@ -56,7 +56,7 @@
   tags: create_bastion, virt-install
   ansible.builtin.shell: |
     virsh destroy {{ env.bastion.vm_name }} || true
-    virsh undefine {{ env.bastion.vm_name }} --remove-all-storage || true
+    virsh undefine {{ env.bastion.vm_name }} --remove-all-storage --nvram || true
     virt-install \
     --name {{ env.bastion.vm_name }} \
     --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \

--- a/roles/create_bastion/templates/bastion-ks.cfg.j2
+++ b/roles/create_bastion/templates/bastion-ks.cfg.j2
@@ -54,11 +54,19 @@ bootloader --append="crashkernel=auto" --location=mbr --boot-drive=vda
 clearpart --all --initlabel --drives=vda
 
 # Disk partitioning information
+{% if env.install_config.control.architecture == 'arm64' %}
+# TODO: Special setup for arm required, becase our arm server requires /boot/efi partition with efi file system
+ignoredisk --only-use=vda
+# System bootloader configuration
+bootloader --location=mbr --boot-drive=vda
+autopart
+{% else %}
 part /boot --fstype="xfs" --asprimary --ondisk=vda --size=1024
 part pv.01 --fstype="lvmpv" --grow --size=1 --ondisk=vda
 volgroup vgsystem --pesize=4096 pv.01
 logvol swap --fstype=swap --name=swap --vgname=vgsystem --size={{ env.bastion.resources.swap }}
 logvol / --fstype=xfs --name=root --vgname=vgsystem --size=1 --grow
+{% endif %}
 
 # Packages selection
 %packages --multilib --ignoremissing

--- a/roles/create_bastion/templates/bastion-ks.cfg.j2
+++ b/roles/create_bastion/templates/bastion-ks.cfg.j2
@@ -55,7 +55,7 @@ clearpart --all --initlabel --drives=vda
 
 # Disk partitioning information
 {% if env.install_config.control.architecture == 'arm64' %}
-# TODO: Special setup for arm required, becase our arm server requires /boot/efi partition with efi file system
+# TODO: Special setup for arm required, because our arm server requires /boot/efi partition with efi file system
 ignoredisk --only-use=vda
 # System bootloader configuration
 bootloader --location=mbr --boot-drive=vda

--- a/roles/create_bootstrap/tasks/main.yaml
+++ b/roles/create_bootstrap/tasks/main.yaml
@@ -12,8 +12,8 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.bootstrap.disk_size }}  \
     --ram {{ env.cluster.nodes.bootstrap.ram }} \
-    {% if env.cluster.nodes.bootstrap.vcpu_model is defined %}
-    --cpu {{ env.cluster.nodes.bootstrap.vcpu_model }} \
+    {% if env.cluster.nodes.bootstrap.vcpu_model_option is defined %}
+    {{ env.cluster.nodes.bootstrap.vcpu_model_option }} \
     {% else %}
     --cpu host \
     {% endif %}

--- a/roles/create_bootstrap/tasks/main.yaml
+++ b/roles/create_bootstrap/tasks/main.yaml
@@ -5,14 +5,18 @@
   tags: create_bootstrap
   ansible.builtin.shell: |
     virsh destroy {{ env.cluster.nodes.bootstrap.vm_name }} || true
-    virsh undefine {{ env.cluster.nodes.bootstrap.vm_name }} --remove-all-storage || true
+    virsh undefine {{ env.cluster.nodes.bootstrap.vm_name }} --remove-all-storage --nvram || true
     virt-install \
     --name {{ env.cluster.nodes.bootstrap.vm_name }} \
     --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.bootstrap.disk_size }}  \
     --ram {{ env.cluster.nodes.bootstrap.ram }} \
+{% if env.cluster.nodes.bootstrap.vcpu_model is defined %}
+    --cpu {{ env.cluster.nodes.bootstrap.vcpu_model }} \
+{% else %}
     --cpu host \
+{% endif %}
     --vcpus {{ env.cluster.nodes.bootstrap.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \

--- a/roles/create_bootstrap/tasks/main.yaml
+++ b/roles/create_bootstrap/tasks/main.yaml
@@ -12,11 +12,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.bootstrap.disk_size }}  \
     --ram {{ env.cluster.nodes.bootstrap.ram }} \
-{% if env.cluster.nodes.bootstrap.vcpu_model is defined %}
+    {% if env.cluster.nodes.bootstrap.vcpu_model is defined %}
     --cpu {{ env.cluster.nodes.bootstrap.vcpu_model }} \
-{% else %}
+    {% else %}
     --cpu host \
-{% endif %}
+    {% endif %}
     --vcpus {{ env.cluster.nodes.bootstrap.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \

--- a/roles/create_bootstrap/tasks/main.yaml
+++ b/roles/create_bootstrap/tasks/main.yaml
@@ -12,11 +12,7 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.bootstrap.disk_size }}  \
     --ram {{ env.cluster.nodes.bootstrap.ram }} \
-    {% if env.cluster.nodes.bootstrap.vcpu_model_option is defined %}
     {{ env.cluster.nodes.bootstrap.vcpu_model_option }} \
-    {% else %}
-    --cpu host \
-    {% endif %}
     --vcpus {{ env.cluster.nodes.bootstrap.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \

--- a/roles/create_compute_nodes/tasks/main.yaml
+++ b/roles/create_compute_nodes/tasks/main.yaml
@@ -11,11 +11,7 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
     --ram {{ env.cluster.nodes.compute.ram }} \
-    {% if env.cluster.nodes.compute.vcpu_model_option is defined %}
     {{ env.cluster.nodes.compute.vcpu_model_option }} \
-    {% else %}
-    --cpu host \
-    {% endif %}
     --vcpus {{ env.cluster.nodes.compute.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -45,11 +41,7 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }}  \
     --ram {{ env.cluster.nodes.infra.ram }} \
-    {% if env.cluster.nodes.infra.vcpu_model_option is defined %}
     {{ env.cluster.nodes.infra.vcpu_model_option }} \
-    {% else %}
-    --cpu host \
-    {% endif %}
     --vcpus {{ env.cluster.nodes.infra.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -98,11 +90,7 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
     --ram {{ env.cluster.nodes.compute.ram }} \
-    {% if env.cluster.nodes.compute.vcpu_model_option is defined %}
     {{ env.cluster.nodes.compute.vcpu_model_option }} \
-    {% else %}
-    --cpu host \
-    {% endif %}
     --vcpus {{ env.cluster.nodes.compute.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -131,11 +119,7 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }}  \
     --ram {{ env.cluster.nodes.infra.ram }} \
-    {% if env.cluster.nodes.infra.vcpu_model_option is defined %}
     {{ env.cluster.nodes.infra.vcpu_model_option }} \
-    {% else %}
-    --cpu host \
-    {% endif %}
     --vcpus {{ env.cluster.nodes.infra.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \

--- a/roles/create_compute_nodes/tasks/main.yaml
+++ b/roles/create_compute_nodes/tasks/main.yaml
@@ -11,8 +11,8 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
     --ram {{ env.cluster.nodes.compute.ram }} \
-    {% if env.cluster.nodes.compute.vcpu_model is defined %}
-    --cpu {{ env.cluster.nodes.compute.vcpu_model }} \
+    {% if env.cluster.nodes.compute.vcpu_model_option is defined %}
+    {{ env.cluster.nodes.compute.vcpu_model_option }} \
     {% else %}
     --cpu host \
     {% endif %}
@@ -45,8 +45,8 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }}  \
     --ram {{ env.cluster.nodes.infra.ram }} \
-    {% if env.cluster.nodes.infra.vcpu_model is defined %}
-    --cpu {{ env.cluster.nodes.infra.vcpu_model }} \
+    {% if env.cluster.nodes.infra.vcpu_model_option is defined %}
+    {{ env.cluster.nodes.infra.vcpu_model_option }} \
     {% else %}
     --cpu host \
     {% endif %}
@@ -98,8 +98,8 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
     --ram {{ env.cluster.nodes.compute.ram }} \
-    {% if env.cluster.nodes.compute.vcpu_model is defined %}
-    --cpu {{ env.cluster.nodes.compute.vcpu_model }} \
+    {% if env.cluster.nodes.compute.vcpu_model_option is defined %}
+    {{ env.cluster.nodes.compute.vcpu_model_option }} \
     {% else %}
     --cpu host \
     {% endif %}
@@ -131,8 +131,8 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }}  \
     --ram {{ env.cluster.nodes.infra.ram }} \
-    {% if env.cluster.nodes.infra.vcpu_model is defined %}
-    --cpu {{ env.cluster.nodes.infra.vcpu_model }} \
+    {% if env.cluster.nodes.infra.vcpu_model_option is defined %}
+    {{ env.cluster.nodes.infra.vcpu_model_option }} \
     {% else %}
     --cpu host \
     {% endif %}

--- a/roles/create_compute_nodes/tasks/main.yaml
+++ b/roles/create_compute_nodes/tasks/main.yaml
@@ -4,14 +4,18 @@
   tags: create_compute_nodes
   shell: |
     virsh destroy {{ env.cluster.nodes.compute.vm_name[i] }} || true
-    virsh undefine {{ env.cluster.nodes.compute.vm_name[i] }} --remove-all-storage || true
+    virsh undefine {{ env.cluster.nodes.compute.vm_name[i] }} --remove-all-storage --nvram || true
     virt-install \
     --name {{ env.cluster.nodes.compute.vm_name[i] }} \
     --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
     --ram {{ env.cluster.nodes.compute.ram }} \
+{% if env.cluster.nodes.compute.vcpu_model is defined %}
+    --cpu {{ env.cluster.nodes.compute.vcpu_model }} \
+{% else %}
     --cpu host \
+{% endif %}
     --vcpus {{ env.cluster.nodes.compute.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -41,7 +45,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }}  \
     --ram {{ env.cluster.nodes.infra.ram }} \
+{% if env.cluster.nodes.infra.vcpu_model is defined %}
+    --cpu {{ env.cluster.nodes.infra.vcpu_model }} \
+{% else %}
     --cpu host \
+{% endif %}
     --vcpus {{ env.cluster.nodes.infra.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -90,7 +98,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
     --ram {{ env.cluster.nodes.compute.ram }} \
+{% if env.cluster.nodes.compute.vcpu_model is defined %}
+    --cpu {{ env.cluster.nodes.compute.vcpu_model }} \
+{% else %}
     --cpu host \
+{% endif %}
     --vcpus {{ env.cluster.nodes.compute.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -119,7 +131,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }}  \
     --ram {{ env.cluster.nodes.infra.ram }} \
+{% if env.cluster.nodes.infra.vcpu_model is defined %}
+    --cpu {{ env.cluster.nodes.infra.vcpu_model }} \
+{% else %}
     --cpu host \
+{% endif %}
     --vcpus {{ env.cluster.nodes.infra.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \

--- a/roles/create_compute_nodes/tasks/main.yaml
+++ b/roles/create_compute_nodes/tasks/main.yaml
@@ -11,11 +11,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
     --ram {{ env.cluster.nodes.compute.ram }} \
-{% if env.cluster.nodes.compute.vcpu_model is defined %}
+    {% if env.cluster.nodes.compute.vcpu_model is defined %}
     --cpu {{ env.cluster.nodes.compute.vcpu_model }} \
-{% else %}
+    {% else %}
     --cpu host \
-{% endif %}
+    {% endif %}
     --vcpus {{ env.cluster.nodes.compute.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -45,11 +45,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }}  \
     --ram {{ env.cluster.nodes.infra.ram }} \
-{% if env.cluster.nodes.infra.vcpu_model is defined %}
+    {% if env.cluster.nodes.infra.vcpu_model is defined %}
     --cpu {{ env.cluster.nodes.infra.vcpu_model }} \
-{% else %}
+    {% else %}
     --cpu host \
-{% endif %}
+    {% endif %}
     --vcpus {{ env.cluster.nodes.infra.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -98,11 +98,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
     --ram {{ env.cluster.nodes.compute.ram }} \
-{% if env.cluster.nodes.compute.vcpu_model is defined %}
+    {% if env.cluster.nodes.compute.vcpu_model is defined %}
     --cpu {{ env.cluster.nodes.compute.vcpu_model }} \
-{% else %}
+    {% else %}
     --cpu host \
-{% endif %}
+    {% endif %}
     --vcpus {{ env.cluster.nodes.compute.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -131,11 +131,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }}  \
     --ram {{ env.cluster.nodes.infra.ram }} \
-{% if env.cluster.nodes.infra.vcpu_model is defined %}
+    {% if env.cluster.nodes.infra.vcpu_model is defined %}
     --cpu {{ env.cluster.nodes.infra.vcpu_model }} \
-{% else %}
+    {% else %}
     --cpu host \
-{% endif %}
+    {% endif %}
     --vcpus {{ env.cluster.nodes.infra.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \

--- a/roles/create_control_nodes/tasks/main.yaml
+++ b/roles/create_control_nodes/tasks/main.yaml
@@ -9,11 +9,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }} \
     --ram {{ env.cluster.nodes.control.ram }} \
-{% if env.cluster.nodes.control.vcpu_model is defined %}
+    {% if env.cluster.nodes.control.vcpu_model is defined %}
     --cpu {{ env.cluster.nodes.control.vcpu_model }} \
-{% else %}
+    {% else %}
     --cpu host \
-{% endif %}
+    {% endif %}
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -46,11 +46,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
-{% if env.cluster.nodes.control.vcpu_model is defined %}
+    {% if env.cluster.nodes.control.vcpu_model is defined %}
     --cpu {{ env.cluster.nodes.control.vcpu_model }} \
-{% else %}
+    {% else %}
     --cpu host \
-{% endif %}
+    {% endif %}
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -76,11 +76,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
-{% if env.cluster.nodes.control.vcpu_model is defined %}
+    {% if env.cluster.nodes.control.vcpu_model is defined %}
     --cpu {{ env.cluster.nodes.control.vcpu_model }} \
-{% else %}
+    {% else %}
     --cpu host \
-{% endif %}
+    {% endif %}
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -106,11 +106,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
-{% if env.cluster.nodes.control.vcpu_model is defined %}
+    {% if env.cluster.nodes.control.vcpu_model is defined %}
     --cpu {{ env.cluster.nodes.control.vcpu_model }} \
-{% else %}
+    {% else %}
     --cpu host \
-{% endif %}
+    {% endif %}
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \

--- a/roles/create_control_nodes/tasks/main.yaml
+++ b/roles/create_control_nodes/tasks/main.yaml
@@ -9,8 +9,8 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }} \
     --ram {{ env.cluster.nodes.control.ram }} \
-    {% if env.cluster.nodes.control.vcpu_model is defined %}
-    --cpu {{ env.cluster.nodes.control.vcpu_model }} \
+    {% if env.cluster.nodes.control.vcpu_model_option is defined %}
+    {{ env.cluster.nodes.control.vcpu_model_option }} \
     {% else %}
     --cpu host \
     {% endif %}
@@ -46,8 +46,8 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
-    {% if env.cluster.nodes.control.vcpu_model is defined %}
-    --cpu {{ env.cluster.nodes.control.vcpu_model }} \
+    {% if env.cluster.nodes.control.vcpu_model_option is defined %}
+    {{ env.cluster.nodes.control.vcpu_model_option }} \
     {% else %}
     --cpu host \
     {% endif %}
@@ -76,8 +76,8 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
-    {% if env.cluster.nodes.control.vcpu_model is defined %}
-    --cpu {{ env.cluster.nodes.control.vcpu_model }} \
+    {% if env.cluster.nodes.control.vcpu_model_option is defined %}
+    {{ env.cluster.nodes.control.vcpu_model_option }} \
     {% else %}
     --cpu host \
     {% endif %}
@@ -106,8 +106,8 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
-    {% if env.cluster.nodes.control.vcpu_model is defined %}
-    --cpu {{ env.cluster.nodes.control.vcpu_model }} \
+    {% if env.cluster.nodes.control.vcpu_model_option is defined %}
+    {{ env.cluster.nodes.control.vcpu_model_option }} \
     {% else %}
     --cpu host \
     {% endif %}

--- a/roles/create_control_nodes/tasks/main.yaml
+++ b/roles/create_control_nodes/tasks/main.yaml
@@ -9,11 +9,7 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }} \
     --ram {{ env.cluster.nodes.control.ram }} \
-    {% if env.cluster.nodes.control.vcpu_model_option is defined %}
     {{ env.cluster.nodes.control.vcpu_model_option }} \
-    {% else %}
-    --cpu host \
-    {% endif %}
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -46,11 +42,7 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
-    {% if env.cluster.nodes.control.vcpu_model_option is defined %}
     {{ env.cluster.nodes.control.vcpu_model_option }} \
-    {% else %}
-    --cpu host \
-    {% endif %}
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -76,11 +68,7 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
-    {% if env.cluster.nodes.control.vcpu_model_option is defined %}
     {{ env.cluster.nodes.control.vcpu_model_option }} \
-    {% else %}
-    --cpu host \
-    {% endif %}
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -106,11 +94,7 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
-    {% if env.cluster.nodes.control.vcpu_model_option is defined %}
     {{ env.cluster.nodes.control.vcpu_model_option }} \
-    {% else %}
-    --cpu host \
-    {% endif %}
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \

--- a/roles/create_control_nodes/tasks/main.yaml
+++ b/roles/create_control_nodes/tasks/main.yaml
@@ -9,7 +9,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }} \
     --ram {{ env.cluster.nodes.control.ram }} \
+{% if env.cluster.nodes.control.vcpu_model is defined %}
+    --cpu {{ env.cluster.nodes.control.vcpu_model }} \
+{% else %}
     --cpu host \
+{% endif %}
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -42,7 +46,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
+{% if env.cluster.nodes.control.vcpu_model is defined %}
+    --cpu {{ env.cluster.nodes.control.vcpu_model }} \
+{% else %}
     --cpu host \
+{% endif %}
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -68,7 +76,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
+{% if env.cluster.nodes.control.vcpu_model is defined %}
+    --cpu {{ env.cluster.nodes.control.vcpu_model }} \
+{% else %}
     --cpu host \
+{% endif %}
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
@@ -94,7 +106,11 @@
     --autostart \
     --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
     --ram {{ env.cluster.nodes.control.ram }} \
+{% if env.cluster.nodes.control.vcpu_model is defined %}
+    --cpu {{ env.cluster.nodes.control.vcpu_model }} \
+{% else %}
     --cpu host \
+{% endif %}
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
     --network network={{ env.bridge_name }} \
     --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \

--- a/roles/delete_compute_node/tasks/main.yaml
+++ b/roles/delete_compute_node/tasks/main.yaml
@@ -29,7 +29,7 @@
       ansible.builtin.shell: |
         set -o pipefail
         virsh destroy {{ param_compute_node.vm_name }} || true
-        virsh undefine {{ param_compute_node.vm_name }} --remove-all-storage || true
+        virsh undefine {{ param_compute_node.vm_name }} --remove-all-storage --nvram || true
       register: cmd_output
     - name: Print cmd output
       ansible.builtin.debug:

--- a/roles/delete_nodes/tasks/main.yaml
+++ b/roles/delete_nodes/tasks/main.yaml
@@ -5,7 +5,7 @@
   ansible.builtin.shell: |
     set -o pipefail
     virsh destroy "{{ env.cluster.nodes.bootstrap.vm_name }}" || true
-    virsh undefine "{{ env.cluster.nodes.bootstrap.vm_name }}" --remove-all-storage || true
+    virsh undefine "{{ env.cluster.nodes.bootstrap.vm_name }}" --remove-all-storage --nvram || true
   register: delete_bootstrap
   changed_when: "('destroyed' in delete_bootstrap.stdout) or ('undefined' in delete_bootstrap.stdout)"
 
@@ -14,7 +14,7 @@
   ansible.builtin.shell: |
     set -o pipefail
     virsh destroy {{ item }} || true
-    virsh undefine {{ item }} --remove-all-storage || true
+    virsh undefine {{ item }} --remove-all-storage --nvram || true
   loop: "{{ env.cluster.nodes.control.vm_name + env.cluster.nodes.compute.vm_name \
     if env.cluster.nodes.infra.vm_name is not defined \
     else env.cluster.nodes.control.vm_name + env.cluster.nodes.compute.vm_name + env.cluster.nodes.infra.vm_name }}"


### PR DESCRIPTION
This patch contains several changes which are required to install
OCP on a ARM server.
The new variable 'vcpu_model_option' can be used to configure the
CPU model and CPU features exposed to the guest. The default CPU
model 'host' is currently not supported on ARM servers and must be
defined to the desired value.

Signed-off-by: Klaus Smolin <smolin@de.ibm.com>