### PR TITLE
feat: Add support to create a three node OCP cluster

### DIFF
--- a/docs/run-the-playbooks.md
+++ b/docs/run-the-playbooks.md
@@ -19,11 +19,19 @@ ansible-playbook playbooks/0_setup.yaml
 * Watch Ansible as it completes the installation, correcting errors if they arise.
 * To look at what tasks are running in detail, open the playbook or roles/role-name/tasks/main.yaml
 * Alternatively, to run all the playbooks at once, start the master playbook by running this shell command:
-```
+
+```shell
 ansible-playbook playbooks/site.yaml
 ```
+
 * If the process fails in error, go through the steps in the [troubleshooting](troubleshooting.md) page.
 * At the end of the the last playbook, follow the printed instructions for first-time login to the cluster.
+* If you make cluster configuration changes in all.yaml file, like increased number of nodes or
+a new bastion setup, after you have successfully installed a OCP cluster,
+then you just need to run these playbooks in order:
+  * 5_setup_bastion.yaml
+  * 6_create_nodes.yaml
+  * 7_ocp_verification.yaml
 
 ## 0 Setup Playbook
 ### Overview

--- a/roles/check_nodes/tasks/main.yaml
+++ b/roles/check_nodes/tasks/main.yaml
@@ -7,7 +7,7 @@
   ansible.builtin.shell: |
     set -o pipefail
     oc get nodes | grep "^{{ node | lower }}" | awk '{print $2}'
-  loop: "{{ env.cluster.nodes.control.hostname + env.cluster.nodes.compute.hostname }}"
+  loop: "{{ env.cluster.nodes.control.hostname + (env.cluster.nodes.compute.hostname | default([])) }}"
   loop_control:
     loop_var: node
   register: cmd_output

--- a/roles/create_compute_nodes/tasks/main.yaml
+++ b/roles/create_compute_nodes/tasks/main.yaml
@@ -34,7 +34,7 @@
   loop_control:
     extended: yes
     index_var: i
-  when: env.z.high_availability == False and inventory_hostname == env.z.lpar1.hostname
+  when: env.cluster.nodes.compute.hostname is defined and env.z.high_availability == False and inventory_hostname == env.z.lpar1.hostname
 
 - name: Install CoreOS on infra nodes
   tags: create_compute_nodes

--- a/roles/haproxy/tasks/main.yaml
+++ b/roles/haproxy/tasks/main.yaml
@@ -36,6 +36,18 @@
     extended: yes
     index_var: i
 
+- name: Add control node information to 443 section in haproxy config, when no compute nodes are defined
+  tags: haproxy
+  lineinfile:
+    line: "  server {{ env.cluster.nodes.control.hostname[i] }} {{ env.cluster.nodes.control.hostname[i] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}:443 check inter 1s"
+    path: /etc/haproxy/haproxy.cfg
+    insertafter: "443 section"
+  with_sequence: start=0 end={{(env.cluster.nodes.control.hostname | length) - 1}} stride=1
+  loop_control:
+    extended: yes
+    index_var: i
+  when: env.cluster.nodes.compute.hostname is not defined
+
 - name: Add compute node information to 443 section in haproxy config
   tags: haproxy
   lineinfile:
@@ -59,6 +71,17 @@
     extended: yes
     index_var: i
   when: env.cluster.nodes.infra.hostname is defined
+
+- name: Add control node information to 80 section in haproxy config, when no compute nodes are defined
+  tags: haproxy
+  lineinfile:
+    line: "  server {{ env.cluster.nodes.control.hostname[i] }} {{ env.cluster.nodes.control.hostname[i] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}:80 check inter 1s"
+    path: /etc/haproxy/haproxy.cfg
+  with_sequence: start=0 end={{(env.cluster.nodes.control.hostname | length) - 1}} stride=1
+  loop_control:
+    extended: yes
+    index_var: i
+  when: env.cluster.nodes.compute.hostname is not defined
 
 - name: Add compute node information to 80 section in haproxy config
   tags: haproxy


### PR DESCRIPTION
With this patch you can create a three node OCP cluster, without dedicated compute nodes. You just need to uncomment the compute node hostname definition in the config file (all.yaml).