### PR TITLE
perf: Disable memballon driver on KVM control and compute nodes

### DIFF
--- a/roles/create_compute_node/tasks/main.yaml
+++ b/roles/create_compute_node/tasks/main.yaml
@@ -66,6 +66,7 @@
             ${CPU_MODEL} \
             --vcpus {{ env.cluster.nodes.compute.vcpu }} \
             --network network={{ env.vnet_name }}{{ (',mac=' + param_compute_node.vm_mac) if (param_compute_node.vm_mac is defined and env.use_dhcp) }} \
+            --memballoon none \
             --graphics none \
             --console pty,target_type=serial \
             --wait -1 \

--- a/roles/create_compute_nodes/tasks/main.yaml
+++ b/roles/create_compute_nodes/tasks/main.yaml
@@ -27,6 +27,8 @@
     --extra-args "{{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }}" \
     --extra-args "coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
     --extra-args "{{ _vm_console }}" \
+    --memballoon none \
+    --graphics none \
     --wait=-1 \
     --noautoconsole
   timeout: 360
@@ -57,6 +59,8 @@
     --extra-args "{{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }}" \
     --extra-args "coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
     --extra-args "{{ _vm_console }}" \
+    --memballoon none \
+    --graphics none \
     --wait=-1 \
     --noautoconsole
   with_sequence: start=0 end={{ ( env.cluster.nodes.infra.hostname | length ) - 1}} stride=1
@@ -110,6 +114,8 @@
     --extra-args "{{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }}" \
     --extra-args "coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
     --extra-args "{{ _vm_console }}" \
+    --memballoon none \
+    --graphics none \
     --wait=-1 \
     --noautoconsole
   loop: "{{ compute_name | zip(compute_hostname, compute_ip) | list }}"
@@ -139,6 +145,8 @@
     --extra-args "{{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }}" \
     --extra-args "coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/worker.ign" \
     --extra-args "{{ _vm_console }}" \
+    --memballoon none \
+    --graphics none \
     --wait=-1 \
     --noautoconsole
   loop: "{{ infra_name | zip(infra_hostname, infra_ip) | list }}"

--- a/roles/create_control_nodes/tasks/main.yaml
+++ b/roles/create_control_nodes/tasks/main.yaml
@@ -25,6 +25,7 @@
     --extra-args "{{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }}" \
     --extra-args "coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
     --extra-args "{{ _vm_console }}" \
+    --memballoon none \
     --graphics none \
     --console pty,target_type=serial \
     --wait=-1 \
@@ -62,6 +63,7 @@
     --extra-args "{{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }}" \
     --extra-args "coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
     --extra-args "{{ _vm_console }}" \
+    --memballoon none \
     --graphics none \
     --wait=-1 \
     --noautoconsole
@@ -92,6 +94,7 @@
     --extra-args "{{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }}" \
     --extra-args "coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
     --extra-args "{{ _vm_console }}" \
+    --memballoon none \
     --graphics none \
     --wait=-1 \
     --noautoconsole
@@ -122,6 +125,7 @@
     --extra-args "{{ ('--nameserver=' + env.cluster.networking.nameserver2) if env.cluster.networking.nameserver2 is defined else '' }}" \
     --extra-args "coreos.inst.ignition_url=http://{{ env.bastion.networking.ip }}:8080/ignition/master.ign" \
     --extra-args "{{ _vm_console }}" \
+    --memballoon none \
     --graphics none \
     --wait=-1 \
     --noautoconsole


### PR DESCRIPTION
Exclude the memory balloon device, because this is recommended in the OCP docs (chapter: "Recommended host practices for IBM Z & IBM LinuxONE environments".