### PR TITLE
fix: Disable disk device cache

### DIFF
--- a/roles/create_bastion/tasks/main.yaml
+++ b/roles/create_bastion/tasks/main.yaml
@@ -64,7 +64,7 @@
     --memory={{ env.bastion.resources.ram }} \
     --vcpus={{ env.bastion.resources.vcpu }} \
     --location {{ env.file_server.protocol }}://{{ env.file_server.user + ':' + env.file_server.pass + '@' if env.file_server.protocol == 'ftp' else '' }}{{ env.file_server.ip }}{{ ':' + env.file_server.port if env.file_server.port | default('') | length > 0 else '' }}/{{ env.file_server.iso_mount_dir }} \
-    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.bastion.resources.disk_size }} \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.bastion.resources.disk_size }},cache=none,io=native \
     --network network={{ env.vnet_name }}{{ (',mac=' + env.bastion.networking.mac) if (env.bastion.networking.mac is defined and env.use_dhcp) }} \
     --graphics none \
     --console pty,target_type=serial \

--- a/roles/create_bootstrap/tasks/main.yaml
+++ b/roles/create_bootstrap/tasks/main.yaml
@@ -10,7 +10,7 @@
     --name {{ env.cluster.nodes.bootstrap.vm_name }} \
     --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
-    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.bootstrap.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.bootstrap.disk_size }},cache=none,io=native \
     --ram {{ env.cluster.nodes.bootstrap.ram }} \
     {{ env.cluster.nodes.bootstrap.vcpu_model_option }} \
     --vcpus {{ env.cluster.nodes.bootstrap.vcpu }} \

--- a/roles/create_compute_node/tasks/main.yaml
+++ b/roles/create_compute_node/tasks/main.yaml
@@ -61,7 +61,7 @@
             --name {{ param_compute_node.vm_name }} \
             --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
             --autostart \
-            --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
+            --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }},cache=none,io=native \
             --ram {{ env.cluster.nodes.compute.ram }} \
             ${CPU_MODEL} \
             --vcpus {{ env.cluster.nodes.compute.vcpu }} \

--- a/roles/create_compute_nodes/tasks/main.yaml
+++ b/roles/create_compute_nodes/tasks/main.yaml
@@ -9,7 +9,7 @@
     --name {{ env.cluster.nodes.compute.vm_name[i] }} \
     --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
-    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }},cache=none,io=native \
     --ram {{ env.cluster.nodes.compute.ram }} \
     {{ env.cluster.nodes.compute.vcpu_model_option }} \
     --vcpus {{ env.cluster.nodes.compute.vcpu }} \
@@ -43,7 +43,7 @@
     --name {{ env.cluster.nodes.infra.vm_name[i] }} \
     --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
-    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }},cache=none,io=native \
     --ram {{ env.cluster.nodes.infra.ram }} \
     {{ env.cluster.nodes.infra.vcpu_model_option }} \
     --vcpus {{ env.cluster.nodes.infra.vcpu }} \
@@ -92,7 +92,7 @@
     --name {{ compute_name[i] }} \
     --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
-    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.compute.disk_size }},cache=none,io=native \
     --ram {{ env.cluster.nodes.compute.ram }} \
     {{ env.cluster.nodes.compute.vcpu_model_option }} \
     --vcpus {{ env.cluster.nodes.compute.vcpu }} \
@@ -125,7 +125,7 @@
     --name {{ infra_name[i] }} \
     --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
-    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.infra.disk_size }},cache=none,io=native \
     --ram {{ env.cluster.nodes.infra.ram }} \
     {{ env.cluster.nodes.infra.vcpu_model_option }} \
     --vcpus {{ env.cluster.nodes.infra.vcpu }} \

--- a/roles/create_control_nodes/tasks/main.yaml
+++ b/roles/create_control_nodes/tasks/main.yaml
@@ -7,7 +7,7 @@
     --name {{ env.cluster.nodes.control.vm_name[i] }} \
     --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
-    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }} \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }},cache=none,io=native \
     --ram {{ env.cluster.nodes.control.ram }} \
     {{ env.cluster.nodes.control.vcpu_model_option }} \
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
@@ -44,7 +44,7 @@
     --name {{ env.cluster.nodes.control.vm_name[0] }} \
     --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
-    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }},cache=none,io=native \
     --ram {{ env.cluster.nodes.control.ram }} \
     {{ env.cluster.nodes.control.vcpu_model_option }} \
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
@@ -74,7 +74,7 @@
     --name {{ env.cluster.nodes.control.vm_name[1] }} \
     --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
-    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }},cache=none,io=native \
     --ram {{ env.cluster.nodes.control.ram }} \
     {{ env.cluster.nodes.control.vcpu_model_option }} \
     --vcpus {{ env.cluster.nodes.control.vcpu }} \
@@ -104,7 +104,7 @@
     --name {{ env.cluster.nodes.control.vm_name[2] }} \
     --osinfo detect=on,name={{ ('rhel8.6') if rhcos_os_variant is not defined else (rhcos_os_variant) }} \
     --autostart \
-    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }}  \
+    --disk pool={{ env.cluster.networking.metadata_name }}-vdisk,size={{ env.cluster.nodes.control.disk_size }},cache=none,io=native \
     --ram {{ env.cluster.nodes.control.ram }} \
     {{ env.cluster.nodes.control.vcpu_model_option }} \
     --vcpus {{ env.cluster.nodes.control.vcpu }} \


### PR DESCRIPTION
Disable disk device cache, because this is recommended in the OCP docs (chapter: "Recommended host practices for IBM Z & IBM LinuxONE environments").