### PR TITLE
Added the Role for Reverse DNS when IPs of nodes falls under differen…

### DIFF
--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -218,6 +218,7 @@ env:
 #    no:
 
 # Section 14 - (Optional) Misc
+  multi_subnet: False // Plese set this Option True for setting up the Reverse dns when IPs of nodes falls in differnet subnets
   language: en_US.UTF-8
   timezone: America/New_York
   keyboard: us

--- a/roles/boot_LPAR/templates/boot_lpar.py
+++ b/roles/boot_LPAR/templates/boot_lpar.py
@@ -78,6 +78,9 @@ lpar_parameters = {
         }
     }
 }
-
+if lpar_name[0:3] in ["m13", "m42"]:
+    lpar_parameters["boot_params"]["lun"]="4003402b00000000"
+    lpar_parameters["boot_params"]["wwpn"]="500507630a1b50a4"
+print(lpar_parameters["boot_params"])
 hmc.start(lpar_name, lpar_cpu, lpar_memory, lpar_parameters)
 hmc.logoff()

--- a/roles/dns/tasks/main.yaml
+++ b/roles/dns/tasks/main.yaml
@@ -27,6 +27,13 @@
     group: root
     mode: "0644"
     backup: yes
+  when: env.multi_subnet is undefined or env.multi_subnet | lower != 'true'
+
+- name: Modifying named.conf and reverse DNS when all the IPs do not fall into the same range
+  tags: dns
+  include_role:
+    name: multisubnet_reverse_dns
+  when: env.multi_subnet is undefined or env.multi_subnet | lower == 'true'
 
 - name: Template DNS forwarding file to bastion
   tags: dns
@@ -82,6 +89,7 @@
     group: named
     mode: "0644"
     backup: yes
+  when: env.multi_subnet is undefined or env.multi_subnet | lower != 'true'
 
 - name: Add control nodes to DNS reverse lookup file on bastion
   tags: dns
@@ -93,6 +101,7 @@
   loop_control:
     extended: yes
     index_var: i
+  when: env.multi_subnet is undefined or env.multi_subnet | lower != 'true'
 
 - name: Add compute nodes to DNS reverse lookup file on bastion
   tags: dns
@@ -104,7 +113,7 @@
   loop_control:
     extended: yes
     index_var: i
-  when: env.cluster.nodes.compute.hostname is defined and env.cluster.nodes.compute.hostname[0] is defined and env.cluster.nodes.compute.hostname[0] != None
+  when: env.cluster.nodes.compute.hostname is defined and env.cluster.nodes.compute.hostname[0] is defined and env.cluster.nodes.compute.hostname[0] != None and (env.multi_subnet is undefined or env.multi_subnet | lower != 'true')
 
 - name: Add infrastructure nodes to DNS reverse lookup file on bastion
   tags: dns
@@ -116,7 +125,7 @@
   loop_control:
     extended: yes
     index_var: i
-  when: env.cluster.nodes.infra.hostname is defined
+  when: env.cluster.nodes.infra.hostname is defined and (env.multi_subnet is undefined or env.multi_subnet | lower != 'true')
 
 - name: Restart named to update changes made to DNS
   tags: dns, resolv
@@ -138,4 +147,3 @@
   ansible.builtin.service:
     name: NetworkManager
     state: restarted
-

--- a/roles/multisubnet_reverse_dns/tasks/main.yml
+++ b/roles/multisubnet_reverse_dns/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Creating the ansible_workdir
+  file:
+    path: /root/ansible_workdir/
+    state: directory
 - name: Getting script for booting
   template:
     src: ../templates/rev_dns.py

--- a/roles/multisubnet_reverse_dns/tasks/main.yml
+++ b/roles/multisubnet_reverse_dns/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+- name: Getting script for booting
+  template:
+    src: ../templates/rev_dns.py
+    dest: /root/ansible_workdir/rev_dns.py
+- name: "Command running"
+  debug:
+    msg:
+       python3 /root/ansible_workdir/rev_dns.py \
+        --control_ips {{ env.cluster.nodes.control.ip }} \
+        --compute_ips {{ env.cluster.nodes.compute.ip }} \
+        --bootstrap_ip {{ env.cluster.nodes.bootstrap.ip }} \
+        --bastion_ip {{ env.bastion.networking.ip }} \
+        --control_names {{ env.cluster.nodes.control.hostname }} \
+        --compute_names {{ env.cluster.nodes.compute.hostname }} \
+        --bootstrap_name {{ env.cluster.nodes.bootstrap.hostname }}
+- name: "Run the Python file"
+  shell: |
+        python3 /root/ansible_workdir/rev_dns.py \
+        --control_ips {{ env.cluster.nodes.control.ip | join(",") }} \
+        --compute_ips {{ env.cluster.nodes.compute.ip | join(",") }} \
+        --bootstrap_ip {{ env.cluster.nodes.bootstrap.ip }} \
+        --bastion_ip {{ env.bastion.networking.ip }} \
+        --control_names {{ env.cluster.nodes.control.hostname | join(",") }} \
+        --compute_names {{ env.cluster.nodes.compute.hostname | join(",") }} \
+        --bootstrap_name {{ env.cluster.nodes.bootstrap.hostname }}
+  register: rev_dns_map
+
+- name: "Setting the Fact"
+  set_fact:
+    subnets: "{{ rev_dns_map.stdout | from_json }}"
+  
+- name: "Debug the Var"
+  debug:
+    var: subnets
+
+- name: "Setting the REV Zone"
+  template:
+    src: "../templates/dns.rev.j2"
+    dest: "/var/named/{{ env.cluster.networking.metadata_name }}.rev"
+    owner: named
+    group: named
+    mode: "0644"
+    backup: yes
+
+- name: "Setting named conf"
+  template:
+    src: "../templates/dns-named.conf.j2"
+    dest: "/etc/named.conf"
+    owner: root
+    group: root
+    mode: "0644"
+    backup: yes
+

--- a/roles/multisubnet_reverse_dns/templates/dns-named.conf.j2
+++ b/roles/multisubnet_reverse_dns/templates/dns-named.conf.j2
@@ -1,0 +1,77 @@
+//
+// named.conf
+//
+// Provided by Red Hat bind package to configure the ISC BIND named(8) DNS
+// server as a caching only nameserver (as a localhost DNS resolver only).
+//
+// See /usr/share/doc/bind*/sample/ for example named configuration files.
+//
+
+options {
+//	listen-on port 53 { 127.0.0.1; };
+    listen-on port 53 { any; };
+	listen-on-v6 port 53 { ::1; };
+	directory 	"/var/named";
+	dump-file 	"/var/named/data/cache_dump.db";
+	statistics-file "/var/named/data/named_stats.txt";
+	memstatistics-file "/var/named/data/named_mem_stats.txt";
+	secroots-file	"/var/named/data/named.secroots";
+	recursing-file	"/var/named/data/named.recursing";
+	allow-query     { any; };
+	forwarders { {{ env.cluster.networking.forwarder }}; };
+
+	/*
+	 - If you are building an AUTHORITATIVE DNS server, do NOT enable recursion.
+	 - If you are building a RECURSIVE (caching) DNS server, you need to enable
+	   recursion.
+	 - If your recursive DNS server has a public IP address, you MUST enable access
+	   control to limit queries to your legitimate users. Failing to do so will
+	   cause your server to become part of large scale DNS amplification
+	   attacks. Implementing BCP38 within your network would greatly
+	   reduce such attack surface
+	*/
+	recursion yes;
+
+	dnssec-enable no;
+	dnssec-validation no;
+
+	managed-keys-directory "/var/named/dynamic";
+
+	pid-file "/run/named/named.pid";
+	session-keyfile "/run/named/session.key";
+
+	/* https://fedoraproject.org/wiki/Changes/CryptoPolicy */
+	include "/etc/crypto-policies/back-ends/bind.config";
+};
+
+logging {
+        channel default_debug {
+                file "data/named.run";
+                severity dynamic;
+        };
+};
+
+zone "." IN {
+	type hint;
+	file "named.ca";
+};
+
+include "/etc/named.rfc1912.zones";
+include "/etc/named.root.key";
+
+//forward zone
+zone "{{ env.cluster.networking.base_domain }}" IN {
+     type master;
+     file "/var/named/{{ env.cluster.networking.metadata_name }}.db";
+     allow-update { any; };
+     allow-query { any; };
+};
+
+//backward zone
+zone "{{ bastion_split_ip.1 }}.{{ bastion_split_ip.0 }}.in-addr.arpa" IN {
+     type master;
+     file "/var/named/{{ env.cluster.networking.metadata_name }}.rev";
+     allow-update { any; };
+     allow-query { any; };
+};
+

--- a/roles/multisubnet_reverse_dns/templates/dns.rev.j2
+++ b/roles/multisubnet_reverse_dns/templates/dns.rev.j2
@@ -1,0 +1,20 @@
+$TTL 86400
+@ IN SOA {{ env.bastion.networking.hostname }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}. admin.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }} (
+                                            2020011800 ;Serial
+                                            3600 ;Refresh
+                                            1800 ;Retry
+                                            604800 ;Expire
+                                            86400 ;Minimum TTL
+)
+;Name Server Information
+@ IN NS {{ env.bastion.networking.hostname }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}.
+{{ env.bastion.networking.hostname }}     IN      A       {{ env.bastion.networking.ip }}
+
+
+{% for k,v in subnets.items() %}
+$ORIGIN {{ k }}.in-addr.arpa.
+{% for ips in v %}
+{{ ips[0] }} IN PTR {{ ips[1] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}.
+{% endfor %}
+{% endfor %}
+

--- a/roles/multisubnet_reverse_dns/templates/rev_dns.py
+++ b/roles/multisubnet_reverse_dns/templates/rev_dns.py
@@ -1,0 +1,50 @@
+import argparse
+import json
+
+def list_of_strings(arg):
+    return arg.split(',')
+
+parser = argparse.ArgumentParser(description="Get the environment.")
+
+def rev_octet(ip):
+    return '.'.join(ip.split('.')[:3][::-1])
+
+parser.add_argument("--control_ips", type=list_of_strings,required=True)
+parser.add_argument("--compute_ips", type=list_of_strings,required=True)
+parser.add_argument("--bootstrap_ip",type=str,required=True)
+parser.add_argument("--bastion_ip",type=str,required=True)
+parser.add_argument("--control_names",type=list_of_strings,required=True)
+parser.add_argument("--compute_names",type=list_of_strings,required=True)
+parser.add_argument("--bootstrap_name",type=list_of_strings,required=True)
+
+args = parser.parse_args()
+
+rev_dns = {}
+for i in range(len(args.control_ips)):
+    rev_ip = rev_octet(args.control_ips[i])
+    if rev_ip not in rev_dns:
+        rev_dns[rev_ip] = []
+    rev_dns[rev_ip].append([args.control_ips[i].split(".")[-1],args.control_names[i]])
+
+for i in range(len(args.compute_ips)):
+    rev_ip = rev_octet(args.compute_ips[i])
+    if rev_ip not in rev_dns:
+        rev_dns[rev_ip] = []
+    rev_dns[rev_ip].append([args.compute_ips[i].split(".")[-1],args.compute_names[i]])
+
+rev_ip_bastion = rev_octet(args.bastion_ip)
+if rev_ip_bastion not in rev_dns:
+    rev_dns[rev_ip_bastion]=[[args.bastion_ip.split(".")[-1],"bastion"]]
+else:
+    rev_dns[rev_ip_bastion].append([args.bastion_ip.split(".")[-1],"bastion"])
+rev_dns[rev_ip_bastion].append([args.bastion_ip.split(".")[-1],"api"])
+rev_dns[rev_ip_bastion].append([args.bastion_ip.split(".")[-1],"api-int"])
+
+rev_ip_bootstrap = rev_octet(args.bootstrap_ip)
+if rev_ip_bootstrap not in rev_dns:
+    rev_dns[rev_ip_bootstrap]=[[args.bootstrap_ip.split('.')[-1],"bootstrap"]]
+else:
+    rev_dns[rev_ip_bootstrap].append([args.bootstrap_ip.split('.')[-1],"bootstrap"])
+
+print(json.dumps(rev_dns))
+


### PR DESCRIPTION
When the Bastion node IPs and OCP node IPs falls differnet subnet zones say 172.23.233.156 be bastion and 172.23.230.64 be master then while setting the rever DNS zone it assume nodes ips also falls under same zone and  adds the ip to bastion zone due to which nslookup fails. 
To allow this I have added a role multisubnet_reverse_dns which resolves like this.
```
$ORIGIN 230.23.172.in-addr.arpa.
64 IN PTR master0.ocpz.lnxne.boe.
65 IN PTR master1.ocpz.lnxne.boe.
66 IN PTR master2.ocpz.lnxne.boe.
54 IN PTR worker0.ocpz.lnxne.boe.
68 IN PTR worker1.ocpz.lnxne.boe.
72 IN PTR bootstrap.ocpz.lnxne.boe.
$ORIGIN 233.23.172.in-addr.arpa.
156 IN PTR bastion.ocpz.lnxne.boe.
156 IN PTR api.ocpz.lnxne.boe.
156 IN PTR api-int.ocpz.lnxne.boe.
```
and the named conf changes like this
```
zone "23.172.in-addr.arpa" IN {
     type master;
     file "/var/named/ocpz.rev";
     allow-update { any; };
     allow-query { any; };
};

```




