### PR TITLE
fix: Hung condition during update of /etc/hosts

### DIFF
--- a/roles/wait_for_install_complete/tasks/main.yaml
+++ b/roles/wait_for_install_complete/tasks/main.yaml
@@ -11,6 +11,8 @@
       {{ env.bastion.networking.ip }} oauth-openshift.apps.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}
       {{ env.bastion.networking.ip }} console-openshift-console.apps.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}
       {{ env.bastion.networking.ip }} api.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}
+# When you are running AOP inside a container, then you must enable 'unsafe_writes'
+    unsafe_writes: true
   delegate_to: 127.0.0.1
 
 - name: Get OCP URL


### PR DESCRIPTION
This patch solves a hung condition during update of /etc/hosts when
you use a container as control host.

Signed-off-by: Klaus Smolin <smolin@de.ibm.com>