### PR TITLE
Fix: Create bastion with rhel version 9 is failing in latest code

### DIFF
--- a/roles/create_bastion/templates/rhel9-bastion-ks.cfg.j2
+++ b/roles/create_bastion/templates/rhel9-bastion-ks.cfg.j2
@@ -53,7 +53,7 @@ bootloader --append="crashkernel=auto" --location=mbr --boot-drive=vda
 clearpart --all --initlabel --drives=vda
 
 # Disk partitioning information
-{% if install_config.control.architecture == 'arm64' %}
+{% if install_config_vars.control.architecture == 'arm64' %}
 # TODO: Special setup for arm required, because our arm server requires /boot/efi partition with efi file system
 ignoredisk --only-use=vda
 # System bootloader configuration


### PR DESCRIPTION
Fix has been added for issue 337.
``install_config``` was causing issue as it has been renamed as ```install_config_vars``` but it was not rectified in ```create_bastion`` roles.

https://github.com/IBM/Ansible-OpenShift-Provisioning/issues/337 