### PR TITLE
Added fix for issue 336

### DIFF
--- a/roles/install_packages/defaults/main.yaml
+++ b/roles/install_packages/defaults/main.yaml
@@ -1,4 +1,4 @@
 # Packages
 pkgs_controller: [ openssh, expect, sshuttle ]
-pkgs_kvm: [ libguestfs, libvirt-client, libvirt-daemon-config-network, libvirt-daemon-kvm, cockpit-machines, libvirt-devel, virt-top, qemu-kvm, python3-lxml, cockpit, lvm2 ]
+pkgs_kvm: [ libguestfs, libvirt-client, libvirt-daemon-config-network, libvirt-daemon-kvm, cockpit-machines, libvirt-devel, virt-top, qemu-kvm, python3-lxml, cockpit, lvm2, httpd ]
 pkgs_bastion: [ haproxy, httpd, bind, bind-utils, expect, firewalld, mod_ssl, python3-policycoreutils, rsync ]


### PR DESCRIPTION
Added fix for issue KVM Setup playbook is failling while operating on httpd server
RCA: It was getting failed due to httpd server was not installed and playbook trying to perform few operation on httpd

https://github.com/IBM/Ansible-OpenShift-Provisioning/issues/336 