### PR TITLE
fix: HCP - Segregating InfraEnv and Agents into a separate namespace

### DIFF
--- a/roles/boot_agents_hcp/tasks/main.yaml
+++ b/roles/boot_agents_hcp/tasks/main.yaml
@@ -7,7 +7,7 @@
 - name: Boot Agents with pxe artifacts
   shell: |
     {% if hcp.data_plane.kvm.ip_params.static_ip.enabled == true %}
-    mac_address=$(oc get NmStateConfig static-ip-nmstate-config-{{ hcp.control_plane.hosted_cluster_name }}-{{ item }} -n {{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }} -o json | jq -r '.spec.interfaces[] | .macAddress')
+    mac_address=$(oc get NmStateConfig static-ip-nmstate-config-{{ hcp.control_plane.hosted_cluster_name }}-{{ item }} -n {{ hcp.control_plane.hosted_cluster_name }}-agents -o json | jq -r '.spec.interfaces[] | .macAddress')
     {% else %}
     mac_address="{{ hcp.data_plane.kvm.ip_params.mac[item] }}"
     {% endif %}
@@ -41,7 +41,7 @@
 - name: Boot Agents with iso
   shell: |
     {% if hcp.data_plane.kvm.ip_params.static_ip.enabled == true %}
-    mac_address=$(oc get NmStateConfig static-ip-nmstate-config-{{ hcp.control_plane.hosted_cluster_name }}-{{ item }} -n {{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }} -o json | jq -r '.spec.interfaces[] | .macAddress')
+    mac_address=$(oc get NmStateConfig static-ip-nmstate-config-{{ hcp.control_plane.hosted_cluster_name }}-{{ item }} -n {{ hcp.control_plane.hosted_cluster_name }}-agents -o json | jq -r '.spec.interfaces[] | .macAddress')
     {% else %}
     mac_address="{{ hcp.data_plane.kvm.ip_params.mac[item] }}"
     {% endif %}

--- a/roles/boot_zvm_nodes_hcp/tasks/main.yaml
+++ b/roles/boot_zvm_nodes_hcp/tasks/main.yaml
@@ -33,16 +33,16 @@
       when: "{{ hcp.data_plane.zvm.disk_type | lower == 'fcp' }}"
 
     - name: Wait for the agent to come up 
-      shell: oc get agents -n "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}" --no-headers -o custom-columns=NAME:.metadata.name,APPROVED:.spec.approved | awk '$2 == "false"' | wc -l 
+      shell: oc get agents -n "{{ hcp.control_plane.hosted_cluster_name }}-agents" --no-headers -o custom-columns=NAME:.metadata.name,APPROVED:.spec.approved | awk '$2 == "false"' | wc -l 
       register: agent_count
       until: agent_count.stdout | int == 1
       retries: 40
       delay: 10
 
     - name: Get the name of agent 
-      shell: oc get agents -n {{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }} --no-headers -o custom-columns=NAME:.metadata.name,APPROVED:.spec.approved | awk '$2 == "false"' 
+      shell: oc get agents -n {{ hcp.control_plane.hosted_cluster_name }}-agents --no-headers -o custom-columns=NAME:.metadata.name,APPROVED:.spec.approved | awk '$2 == "false"' 
       register: agent_name
 
     - name: Approve agents 	
-      shell: oc -n {{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}  patch agent {{ agent_name.stdout.split(' ')[0]  }} -p '{"spec":{"approved":true,"hostname":"compute-{{ item }}.{{hcp.control_plane.hosted_cluster_name }}.{{ hcp.control_plane.basedomain }}"}}' --type merge
+      shell: oc -n {{ hcp.control_plane.hosted_cluster_name }}-agents  patch agent {{ agent_name.stdout.split(' ')[0]  }} -p '{"spec":{"approved":true,"hostname":"compute-{{ item }}.{{hcp.control_plane.hosted_cluster_name }}.{{ hcp.control_plane.basedomain }}"}}' --type merge
 

--- a/roles/create_hcp_InfraEnv/tasks/main.yaml
+++ b/roles/create_hcp_InfraEnv/tasks/main.yaml
@@ -96,6 +96,19 @@
   retries: 30
   delay: 10
 
+- name: Create Pull Secret for Agents
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: pull-secret
+        namespace: "{{ agents_namespace }}"
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ lookup('file', '/root/ansible_workdir/auth_file') | b64encode }}"
+
 - name: Create InfraEnv.yaml
   template:
     src: InfraEnv.yaml.j2

--- a/roles/create_hcp_InfraEnv/tasks/main.yaml
+++ b/roles/create_hcp_InfraEnv/tasks/main.yaml
@@ -1,21 +1,25 @@
 ---
-- name: Getting Hosted Control Plane Namespace
+- name: Formulating Hosted Control Plane Namespace
   set_fact: 
-    hosted_control_plane_namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
+    agents_namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
 
-- name: Check if Hosted Control Plane Namespace exists 
+- name: Formulating Agents Namespace
+  set_fact: 
+    agents_namespace: "{{ hcp.control_plane.hosted_cluster_name }}-agents"
+
+- name: Check if Agents Namespace exists
   k8s_info:
     api_version: v1
     kind: Namespace
-    name: "{{ hosted_control_plane_namespace }}"
+    name: "{{ agents_namespace }}"
   register: namespace_check
   ignore_errors: yes
 
-- name: Create Hosted Control Plane Namespace 
+- name: Create Agents Namespace 
   k8s:
     api_version: v1
     kind: Namespace
-    name: "{{ hosted_control_plane_namespace }}"
+    name: "{{ agents_namespace }}"
     state: present
   when: namespace_check.resources | length == 0 
 
@@ -55,7 +59,7 @@
     hcp create cluster agent 
     --name={{ hcp.control_plane.hosted_cluster_name }} 
     --pull-secret=/root/ansible_workdir/auth_file 
-    --agent-namespace={{ hosted_control_plane_namespace }} 
+    --agent-namespace={{ agents_namespace }} 
     --namespace={{ hcp.control_plane.clusters_namespace }} 
     --base-domain={{ hcp.control_plane.basedomain }} 
     --api-server-address=api.{{ hcp.control_plane.hosted_cluster_name }}.{{ hcp.control_plane.basedomain }} 
@@ -78,14 +82,14 @@
 - name: Waiting for Hosted Control Plane to be available
   command: oc wait --timeout=30m --for=condition=Available --namespace={{ hcp.control_plane.clusters_namespace }} hostedcluster/{{ hcp.control_plane.hosted_cluster_name }}
 
-- name: Wait for pods to come up in Hosted Cluster Namespace
+- name: Wait for pods to come up in Hosted Control Plane Namespace
   shell: oc get pods -n {{ hosted_control_plane_namespace }} | wc -l
   register: pod_count
   until: pod_count.stdout | int > 30
   retries: 40
   delay: 10
 
-- name: Wait for all pods to be in Running State in  Hosted Cluster Namespace
+- name: Wait for all pods to be in Running State in  Hosted Control Plane Namespace
   shell: oc get pods -n {{ hosted_control_plane_namespace }}  --no-headers | grep -v 'Running\|Completed\|Terminating' | wc -l
   register: pod_status
   until: pod_status.stdout == '0'
@@ -139,7 +143,7 @@
   loop: "{{ range(hcp.data_plane.compute_count|int) | list }}"
 
 - name: Wait for ISO to generate in InfraEnv 
-  shell: oc get InfraEnv -n  {{ hosted_control_plane_namespace }} --no-headers
+  shell: oc get InfraEnv -n  {{ agents_namespace }} --no-headers
   register: infra
   until: infra.stdout.split(' ')[-1] != ''
   retries: 60

--- a/roles/create_hcp_InfraEnv/tasks/main.yaml
+++ b/roles/create_hcp_InfraEnv/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Formulating Hosted Control Plane Namespace
   set_fact: 
-    agents_namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
+    hosted_control_plane_namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
 
 - name: Formulating Agents Namespace
   set_fact: 

--- a/roles/create_hcp_InfraEnv/tasks/main.yaml
+++ b/roles/create_hcp_InfraEnv/tasks/main.yaml
@@ -107,7 +107,7 @@
         namespace: "{{ agents_namespace }}"
       type: kubernetes.io/dockerconfigjson
       data:
-        .dockerconfigjson: "{{ lookup('file', '/root/ansible_workdir/auth_file') | b64encode }}"
+        .dockerconfigjson: "{{ hcp.control_plane.pull_secret | b64encode }}"
 
 - name: Create InfraEnv.yaml
   template:

--- a/roles/create_hcp_InfraEnv/templates/InfraEnv.yaml.j2
+++ b/roles/create_hcp_InfraEnv/templates/InfraEnv.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: agent-install.openshift.io/v1beta1
 kind: InfraEnv
 metadata:
   name: "{{ hcp.control_plane.hosted_cluster_name }}"
-  namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
+  namespace: "{{ hcp.control_plane.hosted_cluster_name }}-agents"
 spec:
 {% if hcp.data_plane.kvm.ip_params.static_ip.enabled == true %}
   nmStateConfigLabelSelector:

--- a/roles/create_hcp_InfraEnv/templates/nmStateConfig.yaml.j2
+++ b/roles/create_hcp_InfraEnv/templates/nmStateConfig.yaml.j2
@@ -2,7 +2,7 @@ apiVersion: agent-install.openshift.io/v1beta1
 kind: NMStateConfig
 metadata:
   name: "static-ip-nmstate-config-{{ hcp.control_plane.hosted_cluster_name }}-{{ item }}"
-  namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
+  namespace: "{{ hcp.control_plane.hosted_cluster_name }}-agents"
   labels:
     infraenv: "static-ip-{{ hcp.control_plane.hosted_cluster_name }}"
 spec:

--- a/roles/delete_resources_bastion_hcp/tasks/main.yaml
+++ b/roles/delete_resources_bastion_hcp/tasks/main.yaml
@@ -29,7 +29,7 @@
       loop: "{{ range(hcp.data_plane.compute_count|int) | list }}"
 
     - name: Get machine names
-      command: oc get machine.cluster.x-k8s.io -n {{ hcp.control_plane.hosted_cluster_name }}-agents --no-headers
+      command: oc get machine.cluster.x-k8s.io -n {{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }} --no-headers
       register: machines_info
 
     - name: Create List for machines
@@ -42,14 +42,14 @@
       loop: "{{ range(hcp.data_plane.compute_count|int) | list }}"
 
     - name: Patch the machines to remove finalizers
-      shell: oc patch machine.cluster.x-k8s.io "{{ machines[item] }}" -n "{{ hcp.control_plane.hosted_cluster_name }}-agents" -p '{"metadata":{"finalizers":null}}' --type=merge
+      shell: oc patch machine.cluster.x-k8s.io "{{ machines[item] }}" -n "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}" -p '{"metadata":{"finalizers":null}}' --type=merge
       loop: "{{ range(hcp.data_plane.compute_count|int) | list }}"
 
 - name: Wait for Agentmachines to delete
   k8s_info:
     api_version: capi-provider.agent-install.openshift.io/v1alpha1
     kind: AgentMachine
-    namespace: "{{ hcp.control_plane.hosted_cluster_name }}-agents"
+    namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
   register: agent_machines
   until: agent_machines.resources | length == 0
   retries: 30
@@ -59,7 +59,7 @@
   k8s_info:
     api_version: cluster.x-k8s.io/v1beta1
     kind: Machine
-    namespace: "{{ hcp.control_plane.hosted_cluster_name }}-agents"
+    namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
   register: machines
   until: machines.resources | length == 0
   retries: 30

--- a/roles/delete_resources_bastion_hcp/tasks/main.yaml
+++ b/roles/delete_resources_bastion_hcp/tasks/main.yaml
@@ -29,7 +29,7 @@
       loop: "{{ range(hcp.data_plane.compute_count|int) | list }}"
 
     - name: Get machine names
-      command: oc get machine.cluster.x-k8s.io -n {{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }} --no-headers
+      command: oc get machine.cluster.x-k8s.io -n {{ hcp.control_plane.hosted_cluster_name }}-agents --no-headers
       register: machines_info
 
     - name: Create List for machines
@@ -42,14 +42,14 @@
       loop: "{{ range(hcp.data_plane.compute_count|int) | list }}"
 
     - name: Patch the machines to remove finalizers
-      shell: oc patch machine.cluster.x-k8s.io "{{ machines[item] }}" -n "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}" -p '{"metadata":{"finalizers":null}}' --type=merge
+      shell: oc patch machine.cluster.x-k8s.io "{{ machines[item] }}" -n "{{ hcp.control_plane.hosted_cluster_name }}-agents" -p '{"metadata":{"finalizers":null}}' --type=merge
       loop: "{{ range(hcp.data_plane.compute_count|int) | list }}"
 
 - name: Wait for Agentmachines to delete
   k8s_info:
     api_version: capi-provider.agent-install.openshift.io/v1alpha1
     kind: AgentMachine
-    namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
+    namespace: "{{ hcp.control_plane.hosted_cluster_name }}-agents"
   register: agent_machines
   until: agent_machines.resources | length == 0
   retries: 30
@@ -59,14 +59,14 @@
   k8s_info:
     api_version: cluster.x-k8s.io/v1beta1
     kind: Machine
-    namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
+    namespace: "{{ hcp.control_plane.hosted_cluster_name }}-agents"
   register: machines
   until: machines.resources | length == 0
   retries: 30
   delay: 10
 
 - name: Get agent names
-  command: oc get agents -n {{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }} --no-headers
+  command: oc get agents -n {{ hcp.control_plane.hosted_cluster_name }}-agents --no-headers
   register: agents_info
 
 - name: Create List for agents
@@ -79,7 +79,7 @@
   loop: "{{ range(hcp.data_plane.compute_count|int) | list }}"
 
 - name: Delete Agents
-  command: oc delete agent {{ agents[item] }} -n {{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }} 
+  command: oc delete agent {{ agents[item] }} -n {{ hcp.control_plane.hosted_cluster_name }}-agents 
   loop: "{{ range(hcp.data_plane.compute_count|int) | list }}"
   
 - name: Remove workdir
@@ -93,7 +93,7 @@
     api_version: agent-install.openshift.io/v1beta1
     kind: InfraEnv
     name: "{{ hcp.control_plane.hosted_cluster_name }}"
-    namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
+    namespace: "{{ hcp.control_plane.hosted_cluster_name }}-agents"
 
 - name: Destroy Hosted Control Plane
   command: hcp destroy cluster agent --name {{ hcp.control_plane.hosted_cluster_name }} --namespace {{ hcp.control_plane.clusters_namespace }}

--- a/roles/delete_resources_kvm_host_hcp/tasks/main.yaml
+++ b/roles/delete_resources_kvm_host_hcp/tasks/main.yaml
@@ -4,32 +4,32 @@
   command: virsh destroy {{ hcp.control_plane.hosted_cluster_name }}-agent-{{ item }} 
   loop: "{{ range(hcp.data_plane.compute_count|int) | list }}"
 
-- name: Undefine Agents
+- name: Undefine the Agents
   command: virsh undefine {{ hcp.control_plane.hosted_cluster_name }}-agent-{{ item }} --remove-all-storage
   loop: "{{ range(hcp.data_plane.compute_count|int) | list }}"
 
-- name: Delete  initrd.img
+- name: Delete the initrd.img
   file:
     path: /var/lib/libvirt/images/pxeboot/initrd.img
     state: absent
   when: ( hcp.data_plane.kvm.boot_method | lower != 'iso' and hcp.compute_node_type | lower == 'kvm' ) or hcp.compute_node_type | lower != 'kvm'
 
-- name: Delete  kernel.img
+- name: Delete the kernel.img
   file:
     path: /var/lib/libvirt/images/pxeboot/kernel.img
     state: absent
   when: ( hcp.data_plane.kvm.boot_method | lower != 'iso' and hcp.compute_node_type | lower == 'kvm' ) or hcp.compute_node_type | lower != 'kvm'
 
-- name: Delete iso
+- name: Delete ISO
   file:
     path: /var/lib/libvirt/images/pxeboot/image.iso
     state: absent
   when: hcp.data_plane.kvm.boot_method | lower == 'iso' and hcp.compute_node_type | lower == 'kvm'
 
-- name: Destroy bastion
+- name: Destroy Bastion
   command: virsh destroy {{ hcp.control_plane.hosted_cluster_name }}-bastion
 
-- name: Undefine bastion
+- name: Undefine Bastion
   command: virsh undefine {{ hcp.control_plane.hosted_cluster_name }}-bastion --remove-all-storage
 
 - name: Stop the storage pool

--- a/roles/download_rootfs_hcp/tasks/main.yaml
+++ b/roles/download_rootfs_hcp/tasks/main.yaml
@@ -39,7 +39,7 @@
   - public
 
 - name: Get URL for rootfs.img
-  shell: oc -n "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}" get InfraEnv "{{ hcp.control_plane.hosted_cluster_name }}" -ojsonpath="{.status.bootArtifacts.rootfs}"
+  shell: oc -n "{{ hcp.control_plane.hosted_cluster_name }}-agents" get InfraEnv "{{ hcp.control_plane.hosted_cluster_name }}" -ojsonpath="{.status.bootArtifacts.rootfs}"
   register: rootfs
 
 - name: Download rootfs.img

--- a/roles/scale_nodepool_and_wait_for_compute_hcp/tasks/main.yaml
+++ b/roles/scale_nodepool_and_wait_for_compute_hcp/tasks/main.yaml
@@ -39,7 +39,7 @@
   k8s_info:
     api_version: capi-provider.agent-install.openshift.io/v1alpha1
     kind: AgentMachine
-    namespace: "{{ hcp.control_plane.hosted_cluster_name }}-agents"
+    namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
   register: agent_machines
   until: agent_machines.resources | length == {{ hcp.data_plane.compute_count }}
   retries: 30
@@ -49,7 +49,7 @@
   k8s_info:
     api_version: cluster.x-k8s.io/v1beta1
     kind: Machine
-    namespace: "{{ hcp.control_plane.hosted_cluster_name }}-agents"
+    namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
   register: machines
   until: machines.resources | length == {{ hcp.data_plane.compute_count }}
   retries: 30

--- a/roles/scale_nodepool_and_wait_for_compute_hcp/tasks/main.yaml
+++ b/roles/scale_nodepool_and_wait_for_compute_hcp/tasks/main.yaml
@@ -4,7 +4,7 @@
   k8s_info:
     api_version: agent-install.openshift.io/v1beta1
     kind: Agent
-    namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
+    namespace: "{{ hcp.control_plane.hosted_cluster_name }}-agents"
   register: agents
   until: agents.resources | length == {{ hcp.data_plane.compute_count }}
   retries: 30
@@ -12,7 +12,7 @@
   when: hcp.compute_node_type | lower != 'zvm'
 
 - name: Get agent names
-  command: oc get agents -n {{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }} --no-headers
+  command: oc get agents -n {{ hcp.control_plane.hosted_cluster_name }}-agents --no-headers
   register: agents_info
   when: hcp.compute_node_type | lower != 'zvm'
 
@@ -28,7 +28,7 @@
   when: hcp.compute_node_type | lower != 'zvm'
 
 - name: Patch Agents
-  shell: oc -n {{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}  patch agent {{ agents[item] }} -p '{"spec":{"approved":true,"hostname":"compute-{{item}}.{{ hcp.control_plane.hosted_cluster_name }}.{{ hcp.control_plane.basedomain }}"}}' --type merge
+  shell: oc -n {{ hcp.control_plane.clusters_namespace }}-agents  patch agent {{ agents[item] }} -p '{"spec":{"approved":true,"hostname":"compute-{{item}}.{{ hcp.control_plane.hosted_cluster_name }}.{{ hcp.control_plane.basedomain }}"}}' --type merge
   loop: "{{ range(hcp.data_plane.compute_count|int) | list }}"
   when: hcp.compute_node_type | lower != 'zvm'
 
@@ -39,7 +39,7 @@
   k8s_info:
     api_version: capi-provider.agent-install.openshift.io/v1alpha1
     kind: AgentMachine
-    namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
+    namespace: "{{ hcp.control_plane.hosted_cluster_name }}-agents"
   register: agent_machines
   until: agent_machines.resources | length == {{ hcp.data_plane.compute_count }}
   retries: 30
@@ -49,7 +49,7 @@
   k8s_info:
     api_version: cluster.x-k8s.io/v1beta1
     kind: Machine
-    namespace: "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}"
+    namespace: "{{ hcp.control_plane.hosted_cluster_name }}-agents"
   register: machines
   until: machines.resources | length == {{ hcp.data_plane.compute_count }}
   retries: 30

--- a/roles/setup_for_agents_hcp/tasks/main.yaml
+++ b/roles/setup_for_agents_hcp/tasks/main.yaml
@@ -6,7 +6,7 @@
     mode: '0755'
 
 - name: Get URL for initrd.img
-  shell: oc -n "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}" get InfraEnv "{{ hcp.control_plane.hosted_cluster_name }}" -ojsonpath="{.status.bootArtifacts.initrd}"
+  shell: oc -n "{{ hcp.control_plane.hosted_cluster_name }}-agents" get InfraEnv "{{ hcp.control_plane.hosted_cluster_name }}" -ojsonpath="{.status.bootArtifacts.initrd}"
   register: initrd
   when: ( hcp.data_plane.kvm.boot_method | lower != 'iso' and hcp.compute_node_type | lower == 'kvm' ) or hcp.compute_node_type | lower != 'kvm'
 
@@ -18,7 +18,7 @@
   when: ( hcp.data_plane.kvm.boot_method | lower != 'iso' and hcp.compute_node_type | lower == 'kvm' ) or hcp.compute_node_type | lower != 'kvm'
 
 - name: Get URL for kernel.img
-  shell: oc -n "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}" get InfraEnv "{{ hcp.control_plane.hosted_cluster_name }}" -ojsonpath="{.status.bootArtifacts.kernel}"
+  shell: oc -n "{{ hcp.control_plane.hosted_cluster_name }}-agents" get InfraEnv "{{ hcp.control_plane.hosted_cluster_name }}" -ojsonpath="{.status.bootArtifacts.kernel}"
   register: kernel
   when: ( hcp.data_plane.kvm.boot_method | lower != 'iso' and hcp.compute_node_type | lower == 'kvm' ) or hcp.compute_node_type | lower != 'kvm'
 
@@ -30,7 +30,7 @@
   when: ( hcp.data_plane.kvm.boot_method | lower != 'iso' and hcp.compute_node_type | lower == 'kvm' ) or hcp.compute_node_type | lower != 'kvm'
 
 - name: Get URL for ISO
-  shell: oc -n "{{ hcp.control_plane.clusters_namespace }}-{{ hcp.control_plane.hosted_cluster_name }}" get InfraEnv "{{ hcp.control_plane.hosted_cluster_name }}" -ojsonpath="{.status.isoDownloadURL}"
+  shell: oc -n "{{ hcp.control_plane.hosted_cluster_name }}-agents" get InfraEnv "{{ hcp.control_plane.hosted_cluster_name }}" -ojsonpath="{.status.isoDownloadURL}"
   register: iso
   when: hcp.data_plane.kvm.boot_method | lower == 'iso' and  hcp.compute_node_type | lower == 'kvm'
 


### PR DESCRIPTION
**HCP Workflow change :** 

- Segregating InfraEnv and Agents into a separate namespace while creating and destroying HCP
- This caters to the best practice installation of HCP and also makes sure the Hosted Control Plane and Data Plane are completely segregated which helps to manage Hosted Cluster easily

**Tested Builds :** [HCP Creation](https://sys-soltest-team-jenkins.swg-devops.com/job/OCP-BOE/job/BOE-HCP/job/agent-hcp-create/354/console) & [HCP Deletion](https://sys-soltest-team-jenkins.swg-devops.com/job/OCP-BOE/job/BOE-HCP/job/agent-hcp-destroy/) 