### PR TITLE
feat: HCP - Support for booting DPM LPAR ans attaching as compute node

### DIFF
--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -367,6 +367,7 @@
 **hcp.data_plane.lpar.nodes.dasd.disk_id** | Disk id for dasd disk to be used for zVM node | 4404 
 **hcp.data_plane.lpar.nodes.lun** | Disk details of fcp disk to be used for zVM node | 0.0.4404
 **hcp.data_plane.lpar.nodes.live_disk.disk_type** | Live disk type for booting LPAR | scsi 
+**hcp.data_plane.lpar.nodes.live_disk.uuid** | UUID for the live disk | 600507000000000000xxxx
 **hcp.data_plane.lpar.nodes.live_disk.devicenr** | devicenr for the live disk | 8001
 **hcp.data_plane.lpar.nodes.live_disk.lun** | lun id  for the live disk | 40xxxxxxxxxxxxx
 **hcp.data_plane.lpar.nodes.live_disk.wwpn** | wwpn for the live disk | 500507630xxxxxxx

--- a/inventories/default/group_vars/hcp.yaml.template
+++ b/inventories/default/group_vars/hcp.yaml.template
@@ -170,8 +170,9 @@ hcp:
           # Live disk details
           live_disk: 
             disk_type: 
-            uuid: ''
             password: ''
+       
+            uuid: ''   # Required only in case of DPM LPAR 
             
 	    # following paramaters are required only in case of classical LPAR
             devicenr: ''

--- a/inventories/default/group_vars/hcp.yaml.template
+++ b/inventories/default/group_vars/hcp.yaml.template
@@ -170,10 +170,14 @@ hcp:
           # Live disk details
           live_disk: 
             disk_type: 
-            devicenr:
-            lun:
-            wwpn:
-            password:
+            uuid: ''
+            password: ''
+            
+	    # following paramaters are required only in case of classical LPAR
+            devicenr: ''
+            lun: ''
+            wwpn: ''
+            
       
       
 

--- a/roles/boot_LPAR/templates/boot_lpar.py
+++ b/roles/boot_LPAR/templates/boot_lpar.py
@@ -20,6 +20,7 @@ parser.add_argument("--initrd", type=str, help="Initrd URI", required=True, defa
 
 #live disk info
 parser.add_argument("--livedisktype", type=str, help="Can be of type dasd or scsi", required=True, default='')
+parser.add_argument("--livediskuuid", type=str, help="UUID for the live disk image")
 parser.add_argument("--devicenr", type=str, help="deviceenr for the live disk image")
 parser.add_argument("--netset_ip", type=str, help="network setup ip for the live image")
 parser.add_argument("--netset_gateway", type=str)
@@ -62,6 +63,7 @@ lpar_memory = args.memory
 lpar_parameters = {
     "boot_params": {
         "boot_method" : args.livedisktype.lower(),
+        "uuid" : args.livediskuuid,
         "devicenr": args.devicenr,
         'netsetup': {
             "mac": None,

--- a/roles/boot_LPAR_hcp/tasks/main.yaml
+++ b/roles/boot_LPAR_hcp/tasks/main.yaml
@@ -24,6 +24,7 @@
         --initrd http://"{{ hcp.bastion_params.ip }}":8080/initrd.img \
         --livedisktype "{{ hcp.data_plane.lpar.nodes[item].live_disk.disk_type }}" \
         --devicenr "{{ hcp.data_plane.lpar.nodes[item].live_disk.devicenr }}" \
+        --livediskuuid "{{ hcp.data_plane.lpar.nodes[item].live_disk.uuid }}" \
         --livedisklun "{{ hcp.data_plane.lpar.nodes[item].live_disk.lun }}" \ 
         --livediskwwpn "{{ hcp.data_plane.lpar.nodes[item].live_disk.wwpn }}" \
         --netset_ip "{{ hcp.data_plane.lpar.nodes[item].interface.ip }}" \


### PR DESCRIPTION
Support for booting DPM LPAR ans attaching as compute node
Network modes: OSA , RoCE
Storage: FCP DASD

Updated documentation 