### PR TITLE
Playbook 3_setup_kvm_host is getting failed on LPAR os version rhel9 or above

### DIFF
--- a/roles/install_packages/defaults/main.yaml
+++ b/roles/install_packages/defaults/main.yaml
@@ -1,4 +1,4 @@
 # Packages
 pkgs_controller: [ openssh, expect, sshuttle ]
-pkgs_kvm: [ libguestfs, libvirt-client, libvirt-daemon-config-network, libvirt-daemon-kvm, cockpit-machines, libvirt-devel, virt-top, qemu-kvm, python3-lxml, cockpit, lvm2, httpd ]
+pkgs_kvm: [ libguestfs, libvirt-client, libvirt-daemon-config-network, libvirt-daemon-kvm, cockpit-machines, virt-top, qemu-kvm, python3-lxml, cockpit, lvm2, httpd ]
 pkgs_bastion: [ haproxy, httpd, bind, bind-utils, expect, firewalld, mod_ssl, python3-policycoreutils, rsync ]

--- a/roles/install_packages/tasks/main.yaml
+++ b/roles/install_packages/tasks/main.yaml
@@ -3,6 +3,19 @@
   tags: install_packages
   debug: msg={{ vars[packages] }} 
 
+- name: Getting RHEL Version
+  shell: awk -F 'release ' '{print $2}' /etc/redhat-release | awk '{print $1}'
+  register: rhel_version
+
+- name: Installing libvirt-devel packages for Linux machines.
+  tags: install_packages
+  become: true
+  ansible.builtin.package:
+    name: "libvirt-devel"
+    state: latest
+    update_cache: yes
+  when: ( ansible_os_family != 'Darwin') and ( rhel_version.stdout| float < 9.0 )
+
 - name: Installing required packages for Linux machines.
   tags: install_packages
   become: true


### PR DESCRIPTION
RCA: Playbook was getting failed due to libvirt-devel packages that is not available for rhel9. 
Fix: Removed libvirt-devel from packages list and installing it only when rhel version in below 9.

This PR contain fix for [Playbook 3_setup_kvm_host is getting failed on LPAR os version rhel9 or above](https://github.com/IBM/Ansible-OpenShift-Provisioning/issues/360)  .