### PR TITLE
Shifted the SSH login setup for control and compute nodes from the bastion to the ABI cluster creation playbook

### DIFF
--- a/playbooks/create_abi_cluster.yaml
+++ b/playbooks/create_abi_cluster.yaml
@@ -41,3 +41,9 @@
   roles:
     - common
     - { role: boot_abi_agents, when: installation_type | lower == 'kvm' }
+
+- name: Setup SSH agent
+  tags: ssh_to_nodes
+  hosts: bastion
+  roles:
+    - ssh_agent

--- a/roles/abi_install_complete/tasks/main.yaml
+++ b/roles/abi_install_complete/tasks/main.yaml
@@ -15,32 +15,3 @@
   # Set wait time to 60 min, because it depends highly on system performance and network speed
   retries: 120
   delay: 30
-
-- name: "SSH in to control/compute nodes from bastion after successful cluster creation"
-  tags: ssh_to_nodes
-  block: 
-    - name: Setting up ssh-agent
-      tags: ssh_to_nodes
-      include_role:
-        name: ssh_agent
-
-    - name: SSH in to control/compute nodes from bastion
-      tags: ssh_to_nodes
-      ansible.builtin.shell: |
-        ssh -o StrictHostKeyChecking=no -i ~/.ssh/{{ env.ansible_key_name }} core@{{ item }}
-      with_items:
-        - "{{ env.cluster.nodes.control.ip }}"
-        - "{{ env.cluster.nodes.compute.ip }}"
-      register: ssh_results
-      retries: 5
-      delay: 10
-      vars:
-        ansible_ssh_common_args: "-o ProxyCommand='ssh -W %h:%p -q root@{{ env.bastion.networking.ip }}'"
-      delegate_to: "{{ env.bastion.networking.ip }}"
-  when: install_complete.finished
-  
-- name: Show the result of the bastion SSH login
-  tags: ssh_to_nodes
-  debug:
-    var: ssh_results
-  when: ssh_results is defined


### PR DESCRIPTION
Shifted the SSH login setup for control and compute nodes from the bastion to the ABI cluster creation playbook