### PR TITLE
Fix: Boot-artifacts has been renamed as required to boot the agents.

### DIFF
--- a/roles/abi_install_complete/tasks/main.yaml
+++ b/roles/abi_install_complete/tasks/main.yaml
@@ -15,7 +15,7 @@
       until: install_complete.finished
       # Set wait time to 71 min, because it depends highly on system performance and network speed
       retries: 141
-      delay: 2
+      delay: 30
   when: not install_config_vars.fips
 
 - name: FIPS wait-for install-complete

--- a/roles/create_agent/tasks/main.yml
+++ b/roles/create_agent/tasks/main.yml
@@ -24,6 +24,19 @@
     chdir: ~/{{ abi.ansible_workdir }}
   when: abi.boot_method | lower == "iso" and install_config_vars.fips
 
+- name: Check is vmlinuz exists in boot-artifacts
+  stat:
+    path: "~/{{ abi.ansible_workdir }}/boot-artifacts/agent.{{ ansible_architecture }}-vmlinuz"
+  register: vmlinuz
+
+- name: Copy and rename vmlinuz as kernel.img for PXE
+  ansible.builtin.copy:
+    src: "~/{{ abi.ansible_workdir }}/boot-artifacts/agent.{{ ansible_architecture }}-vmlinuz"
+    dest: /var/www/html/agent.{{ ansible_architecture }}-kernel.img
+    mode: '644'
+    remote_src: true
+  when: vmlinuz.stat.exists
+
 - name: Copy initrd.img, kernel.img, and rootfs.img for PXE
   ansible.builtin.copy:
     src: "~/{{ abi.ansible_workdir }}/boot-artifacts/"


### PR DESCRIPTION
**Issue:** ABI cluster creation is getting failed in 4.19 installer version https://github.com/IBM/Ansible-OpenShift-Provisioning/issues/401
**RCA:** From 4.19 ocp installer have started generating boot-artifacts with different name like  agent.s390x-kernel.img as  agent.s390x-vmlinuz. While booting agents we are providing agent.s390x-kernel.img as expected but now agent.s390x-kernel.img is not present in boot-artifacts
**Fix:**  Renamed agent.s390x-vmlinuz as agent.s390x-kernel.img because  agent.s390x-vmlinuz has same content as agent.s390x-kernel.img