### PR TITLE
Fix OCP client/installer URL logic to support multi and s390x architecture

### DIFF
--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -229,8 +229,9 @@ day2_compute_node:
 abi:
   flag: False
   ansible_workdir: 'ansible_workdir'
-  ocp_installer_version: '4.15.0-rc.8'
-  ocp_installer_url: 'https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/'
+  ocp_installer_version: '4.18.8'
+  ocp_installer_base_url: 'https://mirror.openshift.com/pub/openshift-v4'
+  architecture: <multi|s390x>  
   boot_method: <pxe|iso>
 
 # Openshift Settings  

--- a/roles/download_ocp_installer/tasks/main.yaml
+++ b/roles/download_ocp_installer/tasks/main.yaml
@@ -1,43 +1,55 @@
 ---
-- name: Download OpenShift Installer (fips=false).
+- name: Set architecture subfolder for URL (only for multi)
+  set_fact:
+    arch_subdir: "{{ 's390x/' if abi.architecture == 'multi' else '' }}"
+
+- name: Set OCP download variables
+  set_fact:
+    ocp_download_url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ arch_subdir }}"
+    ocp_client_tgz: "openshift-client-linux.tar.gz"
+    ocp_installer_tgz: "openshift-install-linux.tar.gz"
+    ocp_install_fips_tgz: "openshift-install-linux"
+
+- name: Download OpenShift Installer (fips=false)
   ansible.builtin.get_url:
-    url: "{{ abi.ocp_installer_url }}{{ abi.ocp_installer_version }}/openshift-install-linux.tar.gz"
-    dest: /tmp
-    mode: '640'
+    url: "{{ ocp_download_url }}{{ ocp_installer_tgz }}"
+    dest: /tmp/{{ ocp_installer_tgz }}
+    mode: '0640'
     validate_certs: false
   when: not install_config_vars.fips
 
-- name: Download OpenShift Installer (fips=true).
+- name: Download OpenShift Installer (fips=true)
   ansible.builtin.get_url:
-    url: "{{ abi.ocp_installer_url }}{{ abi.ocp_installer_version }}/{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz"
-    dest: /tmp
-    mode: '640'
+    url: "{{ ocp_download_url }}{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz"
+    dest: /tmp/{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz
+    mode: '0640'
     validate_certs: false
   when: install_config_vars.fips
 
-- name: Extract & Unzip Downloaded OpenShift Installer tar file on Remote (fips=false)
+- name: Extract OpenShift Installer (fips=false)
   ansible.builtin.unarchive:
-    src: /tmp/openshift-install-linux.tar.gz
+    src: /tmp/{{ ocp_installer_tgz }}
     dest: /usr/local/bin
     remote_src: true
   when: not install_config_vars.fips
 
-- name: Extract & Unzip Downloaded OpenShift Installer tar file on Remote (fips=true)
+- name: Extract OpenShift Installer (fips=true)
   ansible.builtin.unarchive:
     src: /tmp/{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz
     dest: /usr/local/bin
     remote_src: true
   when: install_config_vars.fips
 
-- name: Download OpenShift Client.
+- name: Download OpenShift Client
   ansible.builtin.get_url:
     url: "{{ ocp_download_url }}{{ ocp_client_tgz }}"
-    dest: "/tmp/"
-    mode: "0755"
+    dest: /tmp/{{ ocp_client_tgz }}
+    mode: '0755'
+    validate_certs: false
 
-- name: Extract & Unzip Downloaded OpenShift Client tar file on Remote
+- name: Extract OpenShift Client
   ansible.builtin.unarchive:
-    src: "{{ ocp_download_url }}{{ ocp_client_tgz }}"
+    src: /tmp/{{ ocp_client_tgz }}
     dest: /usr/local/bin
     remote_src: true
 


### PR DESCRIPTION
Updated main.yaml to dynamically construct the correct download URLs based on the architecture specified in all.yaml. This ensures proper support for both 'multi' and 's390x' when downloading OpenShift installer and client binaries.