### PR TITLE
Multiarch support for abi

### DIFF
--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -200,8 +200,10 @@
 :--- | :--- | :---
 **abi.flag** | This is the flag, Will be used to identify during execution. Few checks in the playbook will be depend on this (default value will be False)  | True
 **abi.ansible_workdir** | This will be work directory name, it will keep required data that need to be present during or after execution | ansible_workdir
-**abi.ocp_installer_version** | Version will contain value of openshift-installer binary version user desired to be used | '4.15.0-rc.8'
-**abi.ocp_installer_url** | This is the base url of openshift installer binary it will remain same as static value, User Do not need to give value until user wants to change the mirror | 'https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/'
+**abi.ocp_installer_version** | Version will contain value of openshift-installer binary version user desired to be used | '4.15.8'
+**abi.ocp_installer_url** | This is the base url of openshift installer binary it will remain same as static value, User Do not need to give value until user wants to change the mirror | 'https://mirror.openshift.com/pub/openshift-v4/'
+**abi.architecture** | The installer binary supports two architecture options: multi and s390x. Users are required to specify the appropriate architecture value based on their deployment environment. | 'multi/s390x'
+**abi.boot_method** | Specifies the boot type for Agent-based Installation (ABI). Users must choose either iso or pxe based on the deployment method. Note: iso boot is supported only on KVM platforms. | 'iso/pxe'
 
 ## OpenShift Settings
 * The parameters bellow have a hierachical structure and need to be added to all.yaml in given format. For example if you want to change the hyperthreading (disable) than you need to specify the following value in all.yaml file:

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -201,7 +201,7 @@
 **abi.flag** | This is the flag, Will be used to identify during execution. Few checks in the playbook will be depend on this (default value will be False)  | True
 **abi.ansible_workdir** | This will be work directory name, it will keep required data that need to be present during or after execution | ansible_workdir
 **abi.ocp_installer_version** | Version will contain value of openshift-installer binary version user desired to be used | '4.15.8'
-**abi.ocp_installer_url** | This is the base url of openshift installer binary it will remain same as static value, User Do not need to give value until user wants to change the mirror | 'https://mirror.openshift.com/pub/openshift-v4/'
+**abi.ocp_installer_base_url** | This is the base url of openshift installer binary it will remain same as static value, User Do not need to give value until user wants to change the mirror | 'https://mirror.openshift.com/pub/openshift-v4/'
 **abi.architecture** | The installer binary supports two architecture options: multi and s390x. Users are required to specify the appropriate architecture value based on their deployment environment. | 'multi/s390x'
 **abi.boot_method** | Specifies the boot type for Agent-based Installation (ABI). Users must choose either iso or pxe based on the deployment method. Note: iso boot is supported only on KVM platforms. | 'iso/pxe'
 

--- a/inventories/default/group_vars/all.yaml.template
+++ b/inventories/default/group_vars/all.yaml.template
@@ -229,8 +229,9 @@ day2_compute_node:
 abi:
   flag: False
   ansible_workdir: 'ansible_workdir'
-  ocp_installer_version: '4.15.0-rc.8'
-  ocp_installer_url: 'https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/'
+  ocp_installer_version: '4.18.8'
+  ocp_installer_base_url: 'https://mirror.openshift.com/pub/openshift-v4'
+  architecture: <multi|s390x>  
   boot_method: <pxe|iso>
 
 # Openshift Settings  

--- a/roles/download_ocp_installer/tasks/main.yaml
+++ b/roles/download_ocp_installer/tasks/main.yaml
@@ -1,44 +1,44 @@
 ---
 - name: Download OpenShift Installer (fips=false)
   ansible.builtin.get_url:
-    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}openshift-install-linux.tar.gz"
-    dest: /tmp/openshift-install-linux.tar.gz
+    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}{{ ocp_install_tgz }}"
+    dest: /tmp
     mode: '0640'
     validate_certs: false
   when: not install_config_vars.fips
 
 - name: Download OpenShift Installer (fips=true)
   ansible.builtin.get_url:
-    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}openshift-install-rhel9-{{ install_config_vars.control.architecture }}.tar.gz"
-    dest: /tmp/openshift-install-rhel9-{{ install_config_vars.control.architecture }}.tar.gz
+    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz"
+    dest: /tmp
     mode: '0640'
     validate_certs: false
   when: install_config_vars.fips
 
 - name: Extract OpenShift Installer (fips=false)
   ansible.builtin.unarchive:
-    src: /tmp/openshift-install-linux.tar.gz
+    src: "{{ ocp_download_url }}{{ ocp_install_tgz }}"
     dest: /usr/local/bin
     remote_src: true
   when: not install_config_vars.fips
 
 - name: Extract OpenShift Installer (fips=true)
   ansible.builtin.unarchive:
-    src: /tmp/openshift-install-rhel9-{{ install_config_vars.control.architecture }}.tar.gz
+    src: "{{ ocp_download_url }}{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz"
     dest: /usr/local/bin
     remote_src: true
   when: install_config_vars.fips
 
 - name: Download OpenShift Client
   ansible.builtin.get_url:
-    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}openshift-client-linux.tar.gz"
-    dest: /tmp/openshift-client-linux.tar.gz
+    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}{{ ocp_client_tgz }}"
+    dest: /tmp
     mode: '0755'
     validate_certs: false
 
 - name: Extract OpenShift Client
   ansible.builtin.unarchive:
-    src: /tmp/openshift-client-linux.tar.gz
+    src: "{{ ocp_download_url }}{{ ocp_client_tgz }}"
     dest: /usr/local/bin
     remote_src: true
 

--- a/roles/download_ocp_installer/tasks/main.yaml
+++ b/roles/download_ocp_installer/tasks/main.yaml
@@ -1,43 +1,55 @@
 ---
-- name: Download OpenShift Installer (fips=false).
+- name: Set architecture subfolder for URL (only for multi)
+  set_fact:
+    arch_subdir: "{{ 's390x/' if abi.architecture == 'multi' else '' }}"
+
+- name: Set OCP download variables
+  set_fact:
+    ocp_download_url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ arch_subdir }}"
+    ocp_client_tgz: "openshift-client-linux.tar.gz"
+    ocp_installer_tgz: "openshift-install-linux.tar.gz"
+    ocp_install_fips_tgz: "openshift-install-linux"
+
+- name: Download OpenShift Installer (fips=false)
   ansible.builtin.get_url:
-    url: "{{ abi.ocp_installer_url }}{{ abi.ocp_installer_version }}/openshift-install-linux.tar.gz"
-    dest: /tmp
-    mode: '640'
+    url: "{{ ocp_download_url }}{{ ocp_installer_tgz }}"
+    dest: /tmp/{{ ocp_installer_tgz }}
+    mode: '0640'
     validate_certs: false
   when: not install_config_vars.fips
 
-- name: Download OpenShift Installer (fips=true).
+- name: Download OpenShift Installer (fips=true)
   ansible.builtin.get_url:
-    url: "{{ abi.ocp_installer_url }}{{ abi.ocp_installer_version }}/{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz"
-    dest: /tmp
-    mode: '640'
+    url: "{{ ocp_download_url }}{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz"
+    dest: /tmp/{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz
+    mode: '0640'
     validate_certs: false
   when: install_config_vars.fips
 
-- name: Extract & Unzip Downloaded OpenShift Installer tar file on Remote (fips=false)
+- name: Extract OpenShift Installer (fips=false)
   ansible.builtin.unarchive:
-    src: /tmp/openshift-install-linux.tar.gz
+    src: /tmp/{{ ocp_installer_tgz }}
     dest: /usr/local/bin
     remote_src: true
   when: not install_config_vars.fips
 
-- name: Extract & Unzip Downloaded OpenShift Installer tar file on Remote (fips=true)
+- name: Extract OpenShift Installer (fips=true)
   ansible.builtin.unarchive:
     src: /tmp/{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz
     dest: /usr/local/bin
     remote_src: true
   when: install_config_vars.fips
 
-- name: Download OpenShift Client.
+- name: Download OpenShift Client
   ansible.builtin.get_url:
     url: "{{ ocp_download_url }}{{ ocp_client_tgz }}"
-    dest: "/tmp/"
-    mode: "0755"
+    dest: /tmp/{{ ocp_client_tgz }}
+    mode: '0755'
+    validate_certs: false
 
-- name: Extract & Unzip Downloaded OpenShift Client tar file on Remote
+- name: Extract OpenShift Client
   ansible.builtin.unarchive:
-    src: "{{ ocp_download_url }}{{ ocp_client_tgz }}"
+    src: /tmp/{{ ocp_client_tgz }}
     dest: /usr/local/bin
     remote_src: true
 

--- a/roles/download_ocp_installer/tasks/main.yaml
+++ b/roles/download_ocp_installer/tasks/main.yaml
@@ -2,7 +2,7 @@
 - name: Download OpenShift Installer (fips=false)
   ansible.builtin.get_url:
     url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}{{ ocp_install_tgz }}"
-    dest: /tmp
+    dest: "/tmp/{{ ocp_install_tgz }}"
     mode: '0640'
     validate_certs: false
   when: not install_config_vars.fips
@@ -10,21 +10,21 @@
 - name: Download OpenShift Installer (fips=true)
   ansible.builtin.get_url:
     url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz"
-    dest: /tmp
+    dest: "/tmp/{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz"
     mode: '0640'
     validate_certs: false
   when: install_config_vars.fips
 
 - name: Extract OpenShift Installer (fips=false)
   ansible.builtin.unarchive:
-    src: "{{ ocp_download_url }}{{ ocp_install_tgz }}"
+    src: "/tmp/{{ ocp_install_tgz }}"
     dest: /usr/local/bin
     remote_src: true
   when: not install_config_vars.fips
 
 - name: Extract OpenShift Installer (fips=true)
   ansible.builtin.unarchive:
-    src: "{{ ocp_download_url }}{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz"
+    src: "/tmp/{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz"
     dest: /usr/local/bin
     remote_src: true
   when: install_config_vars.fips
@@ -32,13 +32,13 @@
 - name: Download OpenShift Client
   ansible.builtin.get_url:
     url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}{{ ocp_client_tgz }}"
-    dest: /tmp
+    dest: "/tmp/{{ ocp_client_tgz }}"
     mode: '0755'
     validate_certs: false
 
 - name: Extract OpenShift Client
   ansible.builtin.unarchive:
-    src: "{{ ocp_download_url }}{{ ocp_client_tgz }}"
+    src: "/tmp/{{ ocp_client_tgz }}"
     dest: /usr/local/bin
     remote_src: true
 

--- a/roles/download_ocp_installer/tasks/main.yaml
+++ b/roles/download_ocp_installer/tasks/main.yaml
@@ -1,55 +1,44 @@
 ---
-- name: Set architecture subfolder for URL (only for multi)
-  set_fact:
-    arch_subdir: "{{ 's390x/' if abi.architecture == 'multi' else '' }}"
-
-- name: Set OCP download variables
-  set_fact:
-    ocp_download_url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ arch_subdir }}"
-    ocp_client_tgz: "openshift-client-linux.tar.gz"
-    ocp_installer_tgz: "openshift-install-linux.tar.gz"
-    ocp_install_fips_tgz: "openshift-install-linux"
-
 - name: Download OpenShift Installer (fips=false)
   ansible.builtin.get_url:
-    url: "{{ ocp_download_url }}{{ ocp_installer_tgz }}"
-    dest: /tmp/{{ ocp_installer_tgz }}
+    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}openshift-install-linux.tar.gz"
+    dest: /tmp/openshift-install-linux.tar.gz
     mode: '0640'
     validate_certs: false
   when: not install_config_vars.fips
 
 - name: Download OpenShift Installer (fips=true)
   ansible.builtin.get_url:
-    url: "{{ ocp_download_url }}{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz"
-    dest: /tmp/{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz
+    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}openshift-install-rhel9-{{ install_config_vars.control.architecture }}.tar.gz"
+    dest: /tmp/openshift-install-rhel9-{{ install_config_vars.control.architecture }}.tar.gz
     mode: '0640'
     validate_certs: false
   when: install_config_vars.fips
 
 - name: Extract OpenShift Installer (fips=false)
   ansible.builtin.unarchive:
-    src: /tmp/{{ ocp_installer_tgz }}
+    src: /tmp/openshift-install-linux.tar.gz
     dest: /usr/local/bin
     remote_src: true
   when: not install_config_vars.fips
 
 - name: Extract OpenShift Installer (fips=true)
   ansible.builtin.unarchive:
-    src: /tmp/{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz
+    src: /tmp/openshift-install-rhel9-{{ install_config_vars.control.architecture }}.tar.gz
     dest: /usr/local/bin
     remote_src: true
   when: install_config_vars.fips
 
 - name: Download OpenShift Client
   ansible.builtin.get_url:
-    url: "{{ ocp_download_url }}{{ ocp_client_tgz }}"
-    dest: /tmp/{{ ocp_client_tgz }}
+    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}openshift-client-linux.tar.gz"
+    dest: /tmp/openshift-client-linux.tar.gz
     mode: '0755'
     validate_certs: false
 
 - name: Extract OpenShift Client
   ansible.builtin.unarchive:
-    src: /tmp/{{ ocp_client_tgz }}
+    src: /tmp/openshift-client-linux.tar.gz
     dest: /usr/local/bin
     remote_src: true
 

--- a/roles/download_ocp_installer/tasks/main.yaml
+++ b/roles/download_ocp_installer/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Download OpenShift Installer (fips=false)
   ansible.builtin.get_url:
-    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}{{ ocp_install_tgz }}"
+    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture | lower }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture | lower == 'multi' else '' }}{{ ocp_install_tgz }}"
     dest: "/tmp/{{ ocp_install_tgz }}"
     mode: '0640'
     validate_certs: false
@@ -9,8 +9,8 @@
 
 - name: Download OpenShift Installer (fips=true)
   ansible.builtin.get_url:
-    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz"
-    dest: "/tmp/{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz"
+    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture | lower }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture | lower == 'multi' else '' }}{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture | lower }}.tar.gz"
+    dest: "/tmp/{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture | lower }}.tar.gz"
     mode: '0640'
     validate_certs: false
   when: install_config_vars.fips
@@ -24,14 +24,14 @@
 
 - name: Extract OpenShift Installer (fips=true)
   ansible.builtin.unarchive:
-    src: "/tmp/{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture }}.tar.gz"
+    src: "/tmp/{{ ocp_install_fips_tgz }}-{{ install_config_vars.control.architecture | lower }}.tar.gz"
     dest: /usr/local/bin
     remote_src: true
   when: install_config_vars.fips
 
 - name: Download OpenShift Client
   ansible.builtin.get_url:
-    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture == 'multi' else '' }}{{ ocp_client_tgz }}"
+    url: "{{ abi.ocp_installer_base_url }}/{{ abi.architecture | lower }}/clients/ocp/{{ abi.ocp_installer_version }}/{{ 's390x/' if abi.architecture | lower == 'multi' else '' }}{{ ocp_client_tgz }}"
     dest: "/tmp/{{ ocp_client_tgz }}"
     mode: '0755'
     validate_certs: false


### PR DESCRIPTION
This PR adds support for downloading OpenShift installer and client binaries for both single (s390x) and multi-architecture (multi) configurations.

Changes:
Dynamically constructs the download URL based on the value of abi.architecture.

For multi, appends the architecture-specific subdirectory (s390x/) to the URL.

Ensures the correct binaries are fetched and extracted regardless of the architecture setup.

Purpose:
To streamline support for multi-arch environments while maintaining compatibility with existing single-architecture deployments.