### PR TITLE
Amrut - Fix for Non s390x install config architecture

### DIFF
--- a/roles/get_ocp/templates/install-config.yaml.j2
+++ b/roles/get_ocp/templates/install-config.yaml.j2
@@ -21,12 +21,12 @@ compute:
 - hyperthreading: {{ install_config_vars.compute.hyperthreading }}
   name: worker
   replicas: {{ (env.cluster.nodes.compute.hostname | default('') | length) }}
-  architecture: {{ install_config_vars.compute.architecture }}
+  architecture: {{ env.install_config.compute.architecture }}
 controlPlane:
   hyperthreading: {{ install_config_vars.control.hyperthreading }}
   name: master
   replicas: {{(env.cluster.nodes.control.hostname | length)}}
-  architecture: {{ install_config_vars.control.architecture }}
+  architecture: {{ env.install_config.control.architecture }}
 metadata:
   name: {{ env.cluster.networking.metadata_name }}
 networking:


### PR DESCRIPTION
when trying to install x86 ocp cluster install config take s390x. I should be read from all.yaml install config architecture