### PR TITLE
feat: Added workflows to integrate github actions for PR validations

### DIFF
--- a/.github/workflows/ansible_linter.yaml
+++ b/.github/workflows/ansible_linter.yaml
@@ -33,12 +33,10 @@ jobs:
       - name: Run ansible-lint on changed Ansible files
         run: |
           files=$(git diff --name-only --diff-filter=ACMRT upstream/${{ github.base_ref }} -- '*.yml' '*.yaml')
-          
           if [[ -z "$files" ]]; then
             echo "No yaml files changed"
             exit 0
           fi
-          
           echo "Linting changed Ansible files:"
           echo "$files"
           echo "$files" | xargs ansible-lint

--- a/.github/workflows/ansible_linter.yaml
+++ b/.github/workflows/ansible_linter.yaml
@@ -1,0 +1,44 @@
+name: Ansible_Syntax_Checks
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  ansible-lint:
+    name: Ansible_Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Ansible and ansible-lint
+        run: |
+          python -m pip install --upgrade pip
+          pip install ansible ansible-lint
+
+      - name: Fetch base branch from upstream (handles forks)
+        run: |
+          git remote add upstream https://github.com/${{ github.repository }}.git
+          git fetch upstream ${{ github.base_ref }}
+
+      - name: Run ansible-lint on changed Ansible files
+        run: |
+          files=$(git diff --name-only --diff-filter=ACMRT upstream/${{ github.base_ref }} -- '*.yml' '*.yaml')
+          
+          if [[ -z "$files" ]]; then
+            echo "No yaml files changed"
+            exit 0
+          fi
+          
+          echo "Linting changed Ansible files:"
+          echo "$files"
+          echo "$files" | xargs ansible-lint

--- a/.github/workflows/pr_metadata_checks.yaml
+++ b/.github/workflows/pr_metadata_checks.yaml
@@ -1,0 +1,62 @@
+name: Metadata_Validator
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-pr-title:
+    name: PR_Title_Linter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title syntax
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const validKeywords = ['fix', 'feat', 'chore', 'docs', 'perf', 'test'];
+            const title = context.payload.pull_request?.title || '';
+
+            const match = title.match(/^(\w+):\s.+/);
+            if (!match) {
+              core.setFailed(
+                `Invalid PR title format: "${title}"\n\n` +
+                `PR title must follow this format -> prefix: descriptive message\n\n` +
+                `Example -> feat: Add optional setup_file_server.yaml playbook\n\n` +
+                `Allowed keywords:\n` +
+                `  - {"type": "feat", "section": "Features"}\n` +
+                `  - {"type": "fix", "section": "Bug Fixes"}\n` +
+                `  - {"type": "chore", "section": "Miscellaneous"}\n` +
+                `  - {"type": "docs", "section": "Documentation"}\n` +
+                `  - {"type": "perf", "section": "Performance"}\n` +
+                `  - {"type": "test", "section": "Tests"}\n\n` +
+                `This format helps organize changelogs and enforces clarity.`
+              );
+              return;
+            }
+
+            const keyword = match[1];
+            if (!validKeywords.includes(keyword)) {
+              core.setFailed(`Invalid Prefix "${keyword}"\n` +
+              `Allowed keywords:\n` +
+                `  - {"type": "feat", "section": "Features"}\n` +
+                `  - {"type": "fix", "section": "Bug Fixes"}\n` +
+                `  - {"type": "chore", "section": "Miscellaneous"}\n` +
+                `  - {"type": "docs", "section": "Documentation"}\n` +
+                `  - {"type": "perf", "section": "Performance"}\n` +
+                `  - {"type": "test", "section": "Tests"}\n\n`
+                );
+            }
+
+  check-pr-description:
+    name: PR_Description_Validator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR description presence
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request?.body || '';
+
+            if (!body.trim()) {
+              core.setFailed('PR description (body) must not be empty.');
+            }

--- a/.github/workflows/pr_metadata_checks.yaml
+++ b/.github/workflows/pr_metadata_checks.yaml
@@ -60,4 +60,3 @@ jobs:
             if (!body.trim()) {
               core.setFailed('PR description (body) must not be empty.');
             }
-            

--- a/.github/workflows/pr_metadata_checks.yaml
+++ b/.github/workflows/pr_metadata_checks.yaml
@@ -60,3 +60,4 @@ jobs:
             if (!body.trim()) {
               core.setFailed('PR description (body) must not be empty.');
             }
+            


### PR DESCRIPTION
 Added workflows to integrate github actions for PR validations
 This change will enable 3 jobs :
1. Validate PR title
2. Check for the description 
3. Ansible lint check for the files changed as part of the PR raised.

As a first step,  adding these checks. we can make 1 & 2 as mandatory checks and 3 as an optional check.

