### PR TITLE
Updated hcp.yaml with catalogsource image parameter for MCE installation

### DIFF
--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -290,7 +290,7 @@
 **hcp.pkgs** | list of packages for different hosts | 
 **hcp.mce.version** | version for multicluster-engine Operator | 2.4
 **hcp.mce.instance_name** | name of the MultiClusterEngine instance | engine
-**hcp.mce.catalogsource_name** | Name of the catalogsource for operatorhub | redhat-operators
+**hcp.mce.catalogsource_image** | Image ID for installing MCE | 970287
 **hcp.mce.delete** | true or false - deletes mce and related resources while running deletion playbook | true
 **hcp.asc.url_for_ocp_release_file** | Add URL for OCP release.txt File | https://...  ..../release.txt
 **hcp.asc.db_volume_size** | DatabaseStorage Volume Size | 10Gi

--- a/inventories/default/group_vars/hcp.yaml.template
+++ b/inventories/default/group_vars/hcp.yaml.template
@@ -17,7 +17,7 @@ hcp:
     version:
     instance_name: engine
     delete: false
-    catalogsource_name: redhat-operators 
+    catalogsource_image:    # Required only if we need to create the Catalogsource for installing MCE
 
   # AgentServiceConfig Parameters
 

--- a/roles/install_mce_operator/tasks/main.yaml
+++ b/roles/install_mce_operator/tasks/main.yaml
@@ -1,4 +1,14 @@
 ---
+- name: Create CatalogSource.yaml from template 
+  template:
+    src: CatalogSource.yaml.j2
+    dest: /root/ansible_workdir/CatalogSource.yaml
+  when: hcp.mce.catalogsource_image is defined and hcp.mce.catalogsource_image | length > 0
+
+- name: Deploy CatalogSource
+  command: oc apply -f /root/ansible_workdir/CatalogSource.yaml
+  when: hcp.mce.catalogsource_image is defined and hcp.mce.catalogsource_image | length > 0
+
 - name: Check if multicluster-engine Namespace exists 
   k8s_info:
     api_version: v1

--- a/roles/install_mce_operator/templates/CatalogSource.yaml.j2
+++ b/roles/install_mce_operator/templates/CatalogSource.yaml.j2
@@ -1,0 +1,24 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: redhat-operators
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  publisher: redhat
+  displayName: Red Hat Operators v4.18 Stage
+  image: brew.registry.redhat.io/rh-osbs/iib:{{ hcp.mce.catalogsource_image }}
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/roles/install_mce_operator/templates/Subscription.yaml.j2
+++ b/roles/install_mce_operator/templates/Subscription.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: "{{ hcp.asc.mce_namespace }}"
 spec:
   sourceNamespace: openshift-marketplace
-  source: {{ hcp.mce.catalogsource_name }}
+  source: redhat-operators
   channel: stable-{{ hcp.mce.version }}
   installPlanApproval: Automatic
   name: multicluster-engine


### PR DESCRIPTION
Updated hcp.yaml with catalogsource image parameter for MCE installation. 
So the automation can take care of MCE installations other than the stable versions also by applying the the catalogsource image ID in hcp.yaml.