### PR TITLE
fix: Updated mirror information for HCP templates

### DIFF
--- a/roles/create_agentserviceconfig_hcp/templates/mirror-config.yml.j2
+++ b/roles/create_agentserviceconfig_hcp/templates/mirror-config.yml.j2
@@ -28,5 +28,16 @@ data:
       prefix = ""
 
       [[registry.mirror]]
+        location = "quay.io:443/acm-d"
+        insecure = false
+    
+    [[registry]]
+      location = "registry.redhat.io/multicluster-engine"
+      insecure = false
+      blocked = false
+      mirror-by-digest-only = true
+      prefix = ""
+
+      [[registry.mirror]]
         location = "brew.registry.redhat.io/multicluster-engine"
         insecure = false

--- a/roles/create_hcp_InfraEnv/templates/icsp.yaml.j2
+++ b/roles/create_hcp_InfraEnv/templates/icsp.yaml.j2
@@ -7,3 +7,6 @@
 - mirrors:
   - brew.registry.redhat.io
   source: registry-proxy.engineering.redhat.com
+- mirrors:
+  - quay.io:443/acm-d
+  source: registry.redhat.io/multicluster-engine


### PR DESCRIPTION
Updated mirror information for HCP templates
- Added quay.io:443 as mirror for registry.redhat.io/multicluster-engine , as we are getting new builds in quay.io:443
