### PR TITLE
fix: include cluster metadata name in bastion lookup

### DIFF
--- a/roles/check_dns/tasks/main.yaml
+++ b/roles/check_dns/tasks/main.yaml
@@ -1,21 +1,24 @@
 ---
-
 - name: Check internal cluster DNS resolution for the bastion
   tags: check_dns, dns
-  shell: "dig +short {{ env.bastion.networking.hostname }}.{{ env.bastion.networking.base_domain }} | tail -n1"
+  ansible.builtin.shell: |
+    set -o pipefail
+    dig +short {{ env.bastion.networking.hostname }}.{{ env.cluster.networking.metadata_name }}.{{ env.bastion.networking.base_domain }} | tail -n1
   register: bastion_lookup
   failed_when: env.bastion.networking.ip != bastion_lookup.stdout
-  when: env.bastion.networking.internal_ip is not defined or env.bastion.networking.internal_ip == None
+  when: env.bastion.networking.internal_ip is not defined or env.bastion.networking.internal_ip == none
 
 - name: Check internal cluster DNS resolution for the bastion with Internal_IP
   tags: check_dns, dns
-  shell: "dig +short {{ env.bastion.networking.hostname }}.{{ env.bastion.networking.base_domain }} | tail -n1"
+  ansible.builtin.shell: |
+    set -o pipefail
+    dig +short {{ env.bastion.networking.hostname }}.{{ env.cluster.networking.metadata_name }}.{{ env.bastion.networking.base_domain }} | tail -n1
   register: bastion_lookup
   failed_when: env.bastion.networking.internal_ip != bastion_lookup.stdout
-  when: env.bastion.networking.internal_ip is defined and env.bastion.networking.internal_ip != None
+  when: env.bastion.networking.internal_ip is defined and env.bastion.networking.internal_ip != none
 
 - name: Set expected IP for DNS check
-  set_fact:
+  ansible.builtin.set_fact:
     expected_ip: >-
       {{
         env.bastion.networking.internal_ip
@@ -29,7 +32,9 @@
 
 - name: Check internal cluster DNS resolution for external API and apps services
   tags: check_dns, dns
-  shell: "dig +short {{ item }} | tail -n1"
+  ansible.builtin.shell: |
+    set -o pipefail
+    dig +short {{ item }} | tail -n1
   loop:
     - "api.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}"
     - "apps.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}"
@@ -38,79 +43,92 @@
   changed_when: false
 
 - name: Fail if any external DNS record resolves to wrong IP
-  fail:
+  tags: check_dns, dns
+  ansible.builtin.fail:
     msg: >
       DNS mismatch: {{ item.item }} resolved to {{ item.stdout }},
       expected {{ expected_ip }}
   loop: "{{ services_lookup.results }}"
   when: item.stdout != expected_ip
-  tags: check_dns, dns    
 
 - name: Check internal cluster DNS resolution for internal API services
   tags: check_dns, dns
-  shell: "dig +short api-int.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }} | tail -n1"
+  ansible.builtin.shell: |
+    set -o pipefail
+    dig +short api-int.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }} | tail -n1
   register: api_int_lookup
   changed_when: false
 
 - name: Fail if internal DNS record resolves to wrong IP
-  fail:
+  tags: check_dns, dns
+  ansible.builtin.fail:
     msg: >
       DNS mismatch: api-int.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}
       resolved to {{ api_int_lookup.stdout }},
       expected {{ expected_ip }}
   when: api_int_lookup.stdout != expected_ip
-  tags: check_dns, dns    
-    
+
 - name: Check internal cluster DNS resolution for bootstrap
   tags: check_dns, dns
-  shell: "dig +short {{ env.cluster.nodes.bootstrap.hostname }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }} | tail -n1"
+  ansible.builtin.shell: |
+    set -o pipefail
+    dig +short {{ env.cluster.nodes.bootstrap.hostname }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }} | tail -n1
   register: bootstrap_lookup
   failed_when: env.cluster.nodes.bootstrap.ip != bootstrap_lookup.stdout
   when: env.cluster.nodes.bootstrap is defined
 
 - name: Print results from bootstrap lookup
   tags: check_dns, dns
-  debug:
+  ansible.builtin.debug:
     var: bootstrap_lookup.stdout
   when: env.cluster.nodes.bootstrap is defined
 
 - name: Check control nodes DNS resolution
   tags: check_dns, dns
-  shell: "dig +short {{ env.cluster.nodes.control.hostname[i] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}  | tail -n1"
+  ansible.builtin.shell: |
+    set -o pipefail
+    dig +short {{ env.cluster.nodes.control.hostname[i] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }} | tail -n1
   register: control_lookup
   failed_when: env.cluster.nodes.control.ip[i] != control_lookup.stdout
-  with_sequence: start=0 end={{(env.cluster.nodes.control.hostname | length) - 1}} stride=1
+  with_sequence: start=0 end={{ (env.cluster.nodes.control.hostname | length) - 1 }} stride=1
   loop_control:
-    extended: yes
+    extended: true
     index_var: i
 
 - name: Check compute nodes DNS resolution
   tags: check_dns, dns
-  shell: "dig +short {{ env.cluster.nodes.compute.hostname[i] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}  | tail -n1"
+  ansible.builtin.shell: |
+    set -o pipefail
+    dig +short {{ env.cluster.nodes.compute.hostname[i] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }} | tail -n1
   register: compute_lookup
   failed_when: env.cluster.nodes.compute.ip[i] != compute_lookup.stdout
-  with_sequence: start=0 end={{(env.cluster.nodes.compute.hostname | length) - 1}} stride=1
+  with_sequence: start=0 end={{ (env.cluster.nodes.compute.hostname | length) - 1 }} stride=1
   loop_control:
-    extended: yes
+    extended: true
     index_var: i
-  when: env.cluster.nodes.compute.hostname is defined and env.cluster.nodes.compute.hostname[0] is defined and env.cluster.nodes.compute.hostname[0] != None
+  when:
+    - env.cluster.nodes.compute.hostname is defined
+    - env.cluster.nodes.compute.hostname[0] is defined
+    - env.cluster.nodes.compute.hostname[0] != none
 
 - name: Check infrastructure nodes DNS resolution
   tags: check_dns, dns
-  shell: "dig +short {{ env.cluster.nodes.infra.hostname[i] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }}  | tail -n1"
+  ansible.builtin.shell: |
+    set -o pipefail
+    dig +short {{ env.cluster.nodes.infra.hostname[i] }}.{{ env.cluster.networking.metadata_name }}.{{ env.cluster.networking.base_domain }} | tail -n1
   register: infra_lookup
   failed_when: env.cluster.nodes.infra.ip[i] != infra_lookup.stdout
-  with_sequence: start=0 end={{(env.cluster.nodes.infra.hostname | length) - 1}} stride=1
+  with_sequence: start=0 end={{ (env.cluster.nodes.infra.hostname | length) - 1 }} stride=1
   loop_control:
-    extended: yes
+    extended: true
     index_var: i
   when: env.cluster.nodes.infra.hostname is defined
 
 - name: Check external DNS resolution from forwarder
   tags: check_dns, dns
+  ansible.builtin.command: "nslookup {{ item }}"
   register: external_dns_check
   failed_when: '"server can" in external_dns_check.stdout'
-  command: "nslookup {{ item }}"
   loop:
     - www.google.com
     - www.ibm.com


### PR DESCRIPTION
Description
During the OpenShift Agent-Based Installation (ABI) on s390x, the check_dns role was failing to validate the Bastion host's IP address. This occurred because the dig command was looking for the Bastion at {{ hostname }}.{{ base_domain }}, whereas the internal DNS zone created for the cluster expects the format {{ hostname }}.{{ cluster_metadata_name }}.{{ base_domain }}.

This PR updates the lookup logic to include the cluster metadata name, ensuring that internal connectivity checks pass before the LPARs attempt to pull the MachineOS images.

Changes
File: roles/check_dns/tasks/main.yaml

Logic: Updated shell tasks to include {{ env.cluster.networking.metadata_name }} in the FQDN string for both standard and Internal_IP lookup scenarios.

Impact
Prevents failed_when triggers during the infrastructure validation phase.

Ensures consistent DNS resolution across the bastion and the s390x control/compute nodes.

Testing Performed
Verified dig output manually on the abi-bastion host.

Confirmed the bastion_lookup.stdout matches the expected env.bastion.networking.ip.