### PR TITLE
fix: Make regenerate of ssh keys customizable

### DIFF
--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -13,6 +13,8 @@
 **installation_type** | Can be of type kvm or lpar. Some packages will be ignored for installation in case of non lpar based installation. | kvm 
 **controller_sudo_pass** | The password to the machine running Ansible (localhost). This will only be used for two things. To ensure you've installed the pre-requisite packages if you're on Linux, and to add the login URL to your /etc/hosts file. | Pas$w0rd!
 **cex_device** | Specify the storage device type used for LUKS encryption. This setting determines enable cex MCO Ignition configuration will be applied. Use in combination with the cex parameter.  [dasd, fcp, virt]
+**regenerate_private_key** | <b>(Optional)</b> Controls whether to regenerate SSH private keys during the setup process. Default value is 'full_idempotence'. For usage inside of pipelines where SSH keys already exist, this value should be set to 'never' to preserve existing keys. See detailed description [here:](https://docs.ansible.com/projects/ansible/latest/collections/community/crypto/openssh_keypair_module.html) | full_idempotence
+
 
 ## 2 - LPAR(s)
 **Variable Name** | **Description** | **Example**

--- a/roles/ssh_key_gen/defaults/main.yaml
+++ b/roles/ssh_key_gen/defaults/main.yaml
@@ -1,0 +1,8 @@
+# Configure which situations the module is allowed to regenerate private keys.
+# Choices:
+#   - "never"
+#   - "fail"
+#   - "partial_idempotence"
+#   - "full_idempotence" <- (default)
+#   - "always"
+regenerate_private_key: "full_idempotence"

--- a/roles/ssh_key_gen/tasks/main.yaml
+++ b/roles/ssh_key_gen/tasks/main.yaml
@@ -2,18 +2,18 @@
 
 - name: Check to see if local SSH directory exists
   tags: ssh_key_gen, ssh
-  stat:
+  ansible.builtin.stat:
     path: "~/.ssh"
   register: ssh_directory_exists_check
 
 - name: Create SSH local directory if it doesn't already exist
   tags: ssh_key_gen, ssh
-  file:
+  ansible.builtin.file:
     path: "~/.ssh"
     state: directory
     mode: '700'
   register: ssh_directory_creation
-  when: ssh_directory_exists_check.stat.exists == false
+  when: not ssh_directory_exists_check.stat.exists
 
 - name: Generate an OpenSSH keypair with the default values (4096 bits, RSA)
   tags: ssh_key_gen, ssh
@@ -21,17 +21,19 @@
     path: "~/.ssh/{{ env.ansible_key_name }}"
     passphrase: ""
     comment: "Ansible-OpenShift-Provisioning SSH key"
-    regenerate: full_idempotence
+    regenerate: "{{ regenerate_private_key }}"
   register: ssh_key_creation
 
 - name: Print results of ssh key pair creation
   tags: ssh_key_gen, ssh
-  debug:
-    var: ssh_key_creation
+  ansible.builtin.debug:
+    msg:
+      - "SSH key generated: {{ ssh_key_creation }};"
+      - "Regenerate private key: {{ regenerate_private_key }};"
 
 - name: Save path to key pair for use in ssh-copy-id role
   tags: ssh_key_gen, ssh
-  lineinfile:
+  ansible.builtin.lineinfile:
     search_string: "path_to_key_pair:"
     line: "path_to_key_pair: {{ ssh_key_creation.filename }}.pub"
     path: "{{ inventory_dir }}/group_vars/all.yaml"


### PR DESCRIPTION
Under specific circumstances (e.g. running in pipelines) ansible didn't recognize the existing ssh key well and regenerate the key which lead into problems.
This fix provides a new variable (with a meaningful default) transparent to the existing all.yaml files.
Tested with Tekton pipelines.

AI involved: No