### PR TITLE
feat: Add playbook to download the kubeconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This release was tested with OpenShift v4.19 and below.
 * Added support for zVM Converged Hipersockets for HCP
 * HCP - Support for booting DPM LPAR ans attaching as compute node
 * Support for LPAR as compute nodes for HCP
+* New [`download_kubeconfig`](roles/download_kubeconfig/README.md) role for downloading kubeconfig and kubepassw files from bastion host
 
 ### Bug Fixes
 * Added installation_disk_id to agents for LPAR HCP

--- a/docs/download-kubeconfig-playbook.md
+++ b/docs/download-kubeconfig-playbook.md
@@ -1,0 +1,272 @@
+# Download Kubeconfig Playbook
+
+## Overview
+
+The `download_kubeconfig.yaml` playbook downloads the OpenShift authentication files (`kubeconfig` and `kubepassw`) from the bastion host to the local Ansible controller.
+
+## Playbook File
+
+**Path:** `playbooks/download_kubeconfig.yaml`
+
+## Purpose
+
+This playbook is used to download authentication files from the bastion host after a successful OpenShift installation. These files are needed to:
+
+- Interact with the OpenShift cluster via `oc` or `kubectl`
+- Access the OpenShift web console
+- Perform administrative tasks
+
+## Prerequisites
+
+1. **Bastion host must be configured:**
+   - SSH access to the bastion host must be working
+   - The bastion host must be defined in the Ansible inventory under the `bastion` group
+   - The 0_setup.yaml playbook must have been executed successfully
+
+2. **OpenShift installation must be complete:**
+   - The files `~/ocpinst/auth/kubeconfig` and `~/ocpinst/auth/kubepassw` must exist on the bastion host
+
+3. **Ansible configuration:**
+   - Inventory file must be correctly configured
+   - `group_vars/all.yaml` must be present
+   - `group_vars/secrets.yaml` must be present
+
+## Usage
+
+### Basic Usage
+
+```bash
+ansible-playbook playbooks/download_kubeconfig.yaml --ask-vault-pass
+```
+
+### With Custom Destination Directory
+
+```bash
+ansible-playbook playbooks/download_kubeconfig.yaml \
+  --ask-vault-pass \
+  -e "kubeconfig_dest_dir=/home/user/openshift-configs"
+```
+
+### With Specific Inventory
+
+```bash
+ansible-playbook playbooks/download_kubeconfig.yaml \
+  -i inventories/production/hosts \
+  --ask-vault-pass \
+  -e "kubeconfig_dest_dir=/opt/openshift/production"
+```
+
+### Execute Only Download Tasks (with Tags)
+
+```bash
+ansible-playbook playbooks/download_kubeconfig.yaml \
+  --ask-vault-pass \
+  --tags download_kubeconfig
+```
+
+## Configurable Variables
+
+### Main Variables
+
+| Variable | Default Value | Description | Overridable |
+|----------|---------------|-------------|-------------|
+| `kubeconfig_dest_dir` | `/tmp` | Destination directory on the local controller | Yes |
+| `kubeconfig_source_dir` | `~/ocpinst/auth` | Source directory on the bastion host | Yes |
+| `kubeconfig_files` | `['kubeconfig', 'kubeadmin-password']` | List of files to download | Yes |
+
+### Overriding Variables
+
+#### Method 1: Command Line (recommended for one-time changes)
+
+```bash
+ansible-playbook playbooks/download_kubeconfig.yaml \
+  --ask-vault-pass \
+  -e "kubeconfig_dest_dir=/custom/path"
+```
+
+#### Method 2: In group_vars/all.yaml (recommended for permanent changes)
+
+```yaml
+# inventories/default/group_vars/all.yaml
+kubeconfig_dest_dir: /opt/openshift/configs
+```
+
+#### Method 3: In a separate variables file
+
+```bash
+# Create a file vars/kubeconfig_vars.yaml
+cat > vars/kubeconfig_vars.yaml <<EOF
+kubeconfig_dest_dir: /opt/openshift/configs
+kubeconfig_source_dir: ~/ocpinst/auth
+EOF
+
+# Use the file when executing
+ansible-playbook playbooks/download_kubeconfig.yaml \
+  --ask-vault-pass \
+  -e @vars/kubeconfig_vars.yaml
+```
+
+## Output
+
+### File Structure
+
+The downloaded files are stored in the following structure:
+
+```
+<kubeconfig_dest_dir>/
+└── kubeconfig/
+    ├── kubeconfig
+    └── kubeadmin-password
+```
+
+**Important:** Files are stored in the `kubeconfig/` subdirectory, **not** in `auth/kubeconfig/`.
+
+### Example with Default Values
+
+```
+/tmp/
+└── kubeconfig/
+    ├── kubeconfig
+    └── kubeadmin-password
+```
+
+### Example with Custom Path
+
+```bash
+ansible-playbook playbooks/download_kubeconfig.yaml \
+  --ask-vault-pass \
+  -e "kubeconfig_dest_dir=/home/user/ocp-cluster1"
+```
+
+Result:
+```
+/home/user/ocp-cluster1/
+└── kubeconfig/
+    ├── kubeconfig
+    └── kubeadmin-password
+```
+
+## Using the Downloaded Files
+
+### Using Kubeconfig
+
+```bash
+# Export the kubeconfig file
+export KUBECONFIG=/tmp/kubeconfig/kubeconfig
+
+# Test the connection
+oc whoami
+oc get nodes
+
+# Or use it directly
+oc --kubeconfig=/tmp/kubeconfig/kubeconfig get nodes
+```
+
+### Display Kubeadmin Password
+
+```bash
+cat /tmp/kubeconfig/kubeadmin-password
+```
+
+## Integration in Workflows
+
+### After OpenShift Installation
+
+```bash
+# 1. Install OpenShift
+ansible-playbook playbooks/<0_xxx to 7_xxx>.yaml --ask-vault-password
+or
+ansible-playbook playbooks/reinstall_cluster.yaml --ask-vault-password
+
+
+# 2. Download kubeconfig
+ansible-playbook playbooks/download_kubeconfig.yaml --ask-vault-password
+
+# 3. Use cluster
+export KUBECONFIG=/tmp/kubeconfig/kubeconfig
+oc get nodes
+```
+
+### In a Master Playbook if bastion already exists and 0_setup.yaml was executed successfully
+
+```yaml
+---
+- name: Complete OpenShift Setup
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Install OpenShift
+      ansible.builtin.import_playbook: reinstall_cluster.yaml --ask-vault-password
+
+    - name: Download kubeconfig
+      ansible.builtin.import_playbook: download_kubeconfig.yaml --ask-vault-password
+
+```
+
+## Troubleshooting
+
+### Problem: Files Not Found
+
+**Error:**
+```
+fatal: [bastion]: FAILED! => {"msg": "file not found: ~/ocpinst/auth/kubeconfig"}
+```
+
+**Solution:**
+- Verify that the OpenShift installation is complete
+- Ensure the files exist on the bastion host:
+  ```bash
+  ssh bastion "ls -la ~/ocpinst/auth/"
+  ```
+
+### Problem: SSH Connection Failed
+
+**Error:**
+```
+fatal: [bastion]: UNREACHABLE! => {"msg": "Failed to connect to the host via ssh"}
+```
+
+**Solution:**
+- Check SSH configuration
+- Ensure the SSH key is correct
+- Test the connection manually:
+  ```bash
+  ssh bastion "echo 'Connection successful'"
+  ```
+
+## Best Practices
+
+1. **Secure Storage:**
+   - Store kubeconfig files in a secure location
+   - Set restrictive file permissions:
+     ```bash
+     chmod 600 /tmp/kubeconfig/kubeconfig
+     chmod 600 /tmp/kubeconfig/kubepassw
+     ```
+
+2. **Backup:**
+   - Create backups of authentication files
+   - Store them in multiple secure locations
+
+3. **Versioning:**
+   - Use different directories for different clusters:
+     ```bash
+     ansible-playbook playbooks/download_kubeconfig.yaml \
+       -e "kubeconfig_dest_dir=/opt/openshift/cluster-prod"
+     ```
+
+4. **Automation:**
+   - Integrate the playbook into CI/CD pipelines
+
+## See Also
+
+- [Role Documentation](../roles/download_kubeconfig/README.md)
+- [OpenShift Documentation](https://docs.openshift.com/)
+- [Ansible Documentation](https://docs.ansible.com/)
+
+## Support
+
+For problems or questions:
+1. Check the logs
+2. Consult the documentation
+3. Create an issue in the project repository

--- a/docs/run-the-playbooks.md
+++ b/docs/run-the-playbooks.md
@@ -175,6 +175,11 @@ ansible-playbook playbooks/add_compute_node.yaml --extra-vars "@compute-node.yam
 ### Outcomes
 * The defind compute node will be added or deleted, depends which playbook you have executed.
 
+## Download Kubeconfig Playbook (download_kubeconfig.yaml)
+### Overview
+* Use this playbook to download the kubeconfig file from the bastion to your local machine.
+* For detailed information, see the [Download Kubeconfig Playbook documentation](download-kubeconfig-playbook.md).
+
 ## Master Playbook (site.yaml)
 ### Overview
 * Use this playbook to run all required playbooks (0-7) all at once.

--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -420,3 +420,14 @@
 **cex** | Whether to enable cex based luks encryption, default to False
 **cex_device** | Specify the storage device type used for LUKS encryption. This setting determines which MCO Ignition configuration will be applied from the defaults. Do not override the default value. Use in combination with the cex parameter. | [dasd, fcp, virt]
 **cex_uuid_map** | This var is required only for KVM installations using vfio_ap mediated device. Omit it when deploying on LPAR installation. Use in combination with cex and cex_device. Specify guest hostname: "UUID:domain" UUID can be generated from uuidgen command and domain can be retrieved from lszcrypt | upi-cex-control-1: "68cd2d83-3eef-4e45-b22c-534f90b16cb9:00.0035"
+
+## Additional Parameters (optional)
+
+### Download Kubeconfig
+These parameters control the download of kubeconfig and kubepassw files from the bastion host. See the [`download_kubeconfig`](../roles/download_kubeconfig/README.md) role for more details.
+
+**Variable Name** | **Description** | **Example/Default**
+:--- | :--- | :---
+**kubeconfig_dest_dir** | Destination directory on the local controller where downloaded files will be stored. Files are stored in a `kubeconfig/` subdirectory within this path. | /tmp
+**kubeconfig_source_dir** | Source directory on the bastion host from which files will be downloaded. | ~/ocpinst/auth
+**kubeconfig_files** | List of files to download from the bastion host. | ['kubeconfig', 'kubeadmin-password']

--- a/playbooks/download_kubeconfig.yaml
+++ b/playbooks/download_kubeconfig.yaml
@@ -1,0 +1,11 @@
+---
+- name: Download kubeconfig and kubepassw files from bastion host
+  hosts: bastion
+  gather_facts: false
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/all.yaml"
+    - "{{ inventory_dir }}/group_vars/secrets.yaml"
+  roles:
+    - download_kubeconfig
+
+# Assisted by Bob

--- a/roles/download_kubeconfig/README.md
+++ b/roles/download_kubeconfig/README.md
@@ -1,0 +1,136 @@
+# Ansible Role: download_kubeconfig
+
+This role downloads the kubeconfig and kubepassw files from the bastion host.
+
+## Description
+
+The `download_kubeconfig` role enables downloading OpenShift authentication files from the bastion host to the local controller. The files are downloaded from the `~/ocpinst/auth/` directory on the bastion host and stored in a configurable destination directory.
+
+## Requirements
+
+- Ansible 2.9 or higher
+- SSH access to the bastion host
+- The `kubeconfig` and `kubepassw` files must exist on the bastion host under `~/ocpinst/auth/`
+
+## Role Variables
+
+### Default Variables (defaults/main.yaml)
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+| `kubeconfig_dest_dir` | `/tmp` | Destination directory on the local controller where downloaded files will be stored |
+| `kubeconfig_source_dir` | `~/ocpinst/auth` | Source directory on the bastion host from which files will be downloaded |
+| `kubeconfig_files` | `['kubeconfig', 'kubepassw']` | List of files to download |
+
+### Overriding Variables
+
+Variables can be overridden in several ways:
+
+1. **In the playbook file:**
+```yaml
+- hosts: bastion
+  roles:
+    - role: download_kubeconfig
+      vars:
+        kubeconfig_dest_dir: /custom/path
+```
+
+2. **Via command line:**
+```bash
+ansible-playbook download_kubeconfig.yaml -e "kubeconfig_dest_dir=/custom/path" --ask-vault-password
+```
+
+3. **In group_vars or host_vars:**
+```yaml
+# group_vars/all.yaml
+kubeconfig_dest_dir: /custom/path
+```
+
+## Dependencies
+
+No external role dependencies.
+
+## Example Playbook
+
+### Simple usage with default values
+
+```yaml
+---
+- name: Download kubeconfig files from bastion
+  hosts: bastion
+  gather_facts: false
+  roles:
+    - download_kubeconfig
+```
+
+### Usage with custom destination directory
+
+```yaml
+---
+- name: Download kubeconfig files to custom location
+  hosts: bastion
+  gather_facts: false
+  vars:
+    kubeconfig_dest_dir: /home/user/openshift-configs
+  roles:
+    - download_kubeconfig
+```
+
+### Usage with additional variables
+
+```yaml
+---
+- name: Download kubeconfig files with custom settings
+  hosts: bastion
+  gather_facts: false
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/all.yaml"
+    - "{{ inventory_dir }}/group_vars/secrets.yaml"
+  vars:
+    kubeconfig_dest_dir: /opt/openshift/configs
+  roles:
+    - download_kubeconfig
+```
+
+## Output Structure
+
+The downloaded files are stored in the following structure:
+
+```
+<kubeconfig_dest_dir>/
+└── kubeconfig/
+    ├── kubeconfig
+    └── kubepassw
+```
+
+**Note:** Files are stored directly in the `kubeconfig/` subdirectory, **not** in `auth/kubeconfig/`. This meets the requirement that the destination file structure should be `kubeconfig` instead of `auth`.
+
+### Example with default values
+
+When using default values (`kubeconfig_dest_dir: /tmp`):
+
+```
+/tmp/
+└── kubeconfig/
+    ├── kubeconfig
+    └── kubepassw
+```
+
+## Tags
+
+The role supports the following tags:
+
+- `download_kubeconfig`: Executes only the download tasks
+
+Usage:
+```bash
+ansible-playbook download_kubeconfig.yaml --tags download_kubeconfig --ask-vault-password
+```
+
+## License
+
+See main project license
+
+## Author
+
+Ansible OpenShift Provisioning Team

--- a/roles/download_kubeconfig/defaults/main.yaml
+++ b/roles/download_kubeconfig/defaults/main.yaml
@@ -1,0 +1,11 @@
+---
+# Default destination directory for downloaded kubeconfig files
+kubeconfig_dest_dir: /tmp
+
+# Source paths on bastion host
+kubeconfig_source_dir: ~/ocpinst/auth
+kubeconfig_files:
+  - kubeconfig
+  - kubeadmin-password
+
+# Made with Bob

--- a/roles/download_kubeconfig/tasks/main.yaml
+++ b/roles/download_kubeconfig/tasks/main.yaml
@@ -1,0 +1,23 @@
+---
+- name: Ensure destination directory exists
+  ansible.builtin.file:
+    path: "{{ kubeconfig_dest_dir }}/kubeconfig"
+    state: directory
+    mode: '0755'
+  delegate_to: localhost
+
+- name: Download kubeconfig files from bastion
+  tags:
+    - download_kubeconfig
+  ansible.builtin.fetch:
+    src: "{{ kubeconfig_source_dir }}/{{ item }}"
+    dest: "{{ kubeconfig_dest_dir }}/kubeconfig/{{ item }}"
+    flat: true
+  loop: "{{ kubeconfig_files }}"
+
+- name: Display download location
+  ansible.builtin.debug:
+    msg: "Kubeconfig files downloaded to {{ kubeconfig_dest_dir }}/kubeconfig/"
+  delegate_to: localhost
+
+# Assisted by Bob


### PR DESCRIPTION
This PR is the implementation for:
https://github.com/IBM/Ansible-OpenShift-Provisioning/issues/481

It enables to download the kubeconfig and the kube password from bastion to localhost.
This fix provides a new set of variables (with meaningful defaults) being transparent to the existing all.yaml files.
Tested with Tekton pipelines.


AI involved: yes.