### PR TITLE
fix: Add setting for delay for check nodes

### DIFF
--- a/docs/set-variables-group-vars.md
+++ b/docs/set-variables-group-vars.md
@@ -10,10 +10,11 @@
 ## 1 - Controller
 **Variable Name** | **Description** | **Example**
 :--- | :--- | :---
-**installation_type** | Can be of type kvm or lpar. Some packages will be ignored for installation in case of non lpar based installation. | kvm 
+**installation_type** | Can be of type kvm or lpar. Some packages will be ignored for installation in case of non lpar based installation. | kvm
 **controller_sudo_pass** | The password to the machine running Ansible (localhost). This will only be used for two things. To ensure you've installed the pre-requisite packages if you're on Linux, and to add the login URL to your /etc/hosts file. | Pas$w0rd!
 **cex_device** | Specify the storage device type used for LUKS encryption. This setting determines enable cex MCO Ignition configuration will be applied. Use in combination with the cex parameter.  [dasd, fcp, virt]
 **regenerate_private_key** | <b>(Optional)</b> Controls whether to regenerate SSH private keys during the setup process. Default value is 'full_idempotence'. For usage inside of pipelines where SSH keys already exist, this value should be set to 'never' to preserve existing keys. See detailed description [here:](https://docs.ansible.com/projects/ansible/latest/collections/community/crypto/openssh_keypair_module.html) | full_idempotence
+**check_nodes_delay** | <b>(Optional)</b> Delay in seconds between retries when checking if control and compute nodes are in 'Ready' state. Used during the check_nodes role execution. Default value is 30 seconds. | 30
 
 
 ## 2 - LPAR(s)

--- a/roles/check_nodes/tasks/main.yaml
+++ b/roles/check_nodes/tasks/main.yaml
@@ -13,4 +13,4 @@
   register: cmd_output
   until: ("Ready" == cmd_output.stdout)
   retries: 90
-  delay: 20
+  delay: "{{ check_nodes_delay | default(30) }}"


### PR DESCRIPTION
Environments having performance issue are delayed rolling out the OCP cluster and AOP could fail because of timeouts. This PR makes the wait time for checking the nodes configurable and set the default to 30s instead of 20s.

AI involved: No