### PR TITLE
fix: make day-2 compute install device configurable

### DIFF
--- a/roles/create_compute_node/tasks/main.yaml
+++ b/roles/create_compute_node/tasks/main.yaml
@@ -73,7 +73,7 @@
             --wait -1 \
             --noautoconsole \
             --location {{ rhcos_download_url }},kernel={{ rhcos_live_kernel }},initrd={{ rhcos_live_initrd }} \
-            --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda" \
+            --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev={{ param_compute_node.install_dev | default('vda') }}" \
             {% if (param_compute_node.vm_mac is defined and env.use_dhcp) %}
             --extra-args "ip=dhcp" \
             {% else %}


### PR DESCRIPTION
## Problem
The day-2 compute node flow hardcodes `coreos.inst.install_dev=vda` for CoreOS installation.
This fails on x86_64 KVM environments where the installation disk is typically `/dev/sda`.

## Fix
Replaced the hardcoded value with a configurable parameter:`param_compute_node.install_dev`, defaulting to `vda`.

## Testing Performed
- Attempted day-2 x86_64 compute node addition with hardcoded `vda` and observed failure (disk not found).
- Retried with `param_compute_node.install_dev=sda` and confirmed successful CoreOS installation.

## Impact
- Enables successful day-2 compute node creation on x86_64 systems.
- Preserves existing behavior for environments where `vda` is valid by keeping it as default.