### PR TITLE
docs: update documentation to reflect all supported hypervisors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# Ansible-Automated OpenShift Provisioning on KVM on IBM zSystems / LinuxONE
+# Ansible-Automated OpenShift Provisioning on IBM zSystems / LinuxONE
 The documentation for this project can be found [here](https://ibm.github.io/Ansible-OpenShift-Provisioning/).
+
+**Supported Hypervisors:** KVM, LPAR, z/VM  
+**Installation Methods:** User-Provisioned Infrastructure (UPI), Agent-Based Installer (ABI), Hosted Control Plane (HCP)
 
 Release v2.4.0:
 This README contains the information for the current release only.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,14 @@
-# Ansible-Automated OpenShift Provisioning on KVM on IBM zSystems / LinuxONE
+# Ansible-Automated OpenShift Provisioning on IBM zSystems / LinuxONE
 ## Overview
-These Ansible Playbooks automate the setup and deployment of a Red Hat OpenShift Container Platform (RHOCP) cluster on IBM zSystems / LinuxONE with Kernel Virtual Machine (KVM) as the hypervisor.  
+These Ansible Playbooks automate the setup and deployment of Red Hat OpenShift Container Platform (RHOCP) clusters on IBM zSystems / LinuxONE across multiple hypervisors and installation methods.
+## Supported Configurations
+| Hypervisor | Installation Methods |
+|------------|---------------------|
+| **KVM** | UPI, Agent-Based Installer (ABI), Hosted Control Plane (HCP) |
+| **LPAR** | UPI, Agent-Based Installer (ABI), Hosted Control Plane (HCP) |
+| **z/VM** | UPI, Hosted Control Plane (HCP) |
 <img src="images/overview.png" width="75%"/>
+
 ## Ready to Start?
 Use the left-hand panel to navigate the site. Start with the [Before You Begin](before-you-begin.md) page.
 ## Need Help?


### PR DESCRIPTION
## Fixes #431 - Update documentation to reflect all supported hypervisors and installation methods

### Problem
The documentation incorrectly stated that this project only supports KVM as the hypervisor and only the UPI installation method. This was misleading to users as the project actually supports multiple hypervisors (KVM, LPAR, z/VM) and multiple installation methods (UPI, ABI, HCP).

### Changes Made
- **docs/index.md**: 
  - Removed "on KVM" from title
  - Updated overview to mention "multiple hypervisors and installation methods"
  - Added "Supported Configurations" table showing all hypervisor and installation method combinations
  
- **README.md**:
  - Removed "on KVM" from title
  - Added explicit list of supported hypervisors and installation methods at the top

### Result
Documentation now accurately reflects that the project supports:
- **Hypervisors**: KVM, LPAR, z/VM
- **Installation Methods**: User-Provisioned Infrastructure (UPI), Agent-Based Installer (ABI), Hosted Control Plane (HCP)

The new matrix format makes it easy for unfamiliar users to quickly understand which combinations are supported.

### Testing
- Verified markdown renders correctly
- Confirmed all supported configurations are accurately represented
- Checked consistency across documentation files
