### PR TITLE
feat: Add tear down of cluster for UPI.

### DIFF
--- a/docs/run-the-playbooks.md
+++ b/docs/run-the-playbooks.md
@@ -142,6 +142,39 @@ Final steps of waiting for and verifying the OpenShift cluster to complete its i
 
 # Additional Playbooks
 
+## Delete Cluster Nodes Playbook (delete_cluster_nodes.yaml)
+### Overview
+* Use this playbook to delete all cluster nodes (bootstrap, control, compute, and infra nodes) from the configured KVM hosts based on your `inventories/default/group_vars/all.yaml` configuration.
+* This is useful when you need to tear down the cluster nodes while keeping the bastion and infrastructure intact.
+
+### Usage
+To delete all cluster nodes from all configured KVM hosts:
+```
+ansible-playbook playbooks/delete_cluster_nodes.yaml
+```
+
+To delete nodes from a specific KVM host only, use tags:
+```
+ansible-playbook playbooks/delete_cluster_nodes.yaml --tags kvm_host_1
+ansible-playbook playbooks/delete_cluster_nodes.yaml --tags kvm_host_2
+ansible-playbook playbooks/delete_cluster_nodes.yaml --tags kvm_host_3
+```
+
+### Outcomes
+* All cluster nodes (bootstrap, control, compute, and infra) are destroyed and undefined from the configured KVM hosts.
+* Virtual machine storage is removed.
+* A summary message is displayed upon completion.
+
+### Notes
+* This playbook does **NOT** delete:
+    * The bastion node
+    * Network configurations
+    * Storage pools
+    * DNS or HAProxy configurations
+* To verify deletion, run `virsh list --all` on each KVM host.
+* The playbook uses the existing `delete_nodes` role which safely handles non-existent VMs.
+* If you need to reinstall the cluster after deletion, use the `reinstall_cluster.yaml` playbook or run playbooks 6 and 7.
+
 ## Create additional compute nodes (create_compute_node.yaml) and delete compute nodes (delete_compute_node.yaml)
 ### Overview
 

--- a/inventories/default/hosts
+++ b/inventories/default/hosts
@@ -1,2 +1,10 @@
 [localhost]
-127.0.0.1 ansible_connection=local ansible_become_password=
+127.0.0.1 ansible_connection=local ansible_become_password='{{ controller_sudo_pass }}'
+
+[file_server]
+
+[kvm_host]
+
+[bastion]
+
+[jumphost]

--- a/playbooks/0_setup.yaml
+++ b/playbooks/0_setup.yaml
@@ -25,9 +25,11 @@
   post_tasks:
     - name: Find ibm_zhmc collection install location, if automated LPAR creation is to be used.
       tags: galaxy
-      ansible.builtin.shell: ansible-galaxy collection list ibm.ibm_zhmc | grep -i ansible | cut -c 3-
+      ansible.builtin.shell: |
+        set -o pipefail
+        ansible-galaxy collection list ibm.ibm_zhmc | grep -i ansible | cut -c 3-
       register: zhmc_path
-      when: env.z.lpar1.create == True or env.z.lpar2.create == True or env.z.lpar3.create == True
+      when: env.z.lpar1.create or env.z.lpar2.create or env.z.lpar3.create
 
     - name: Ensure zhmcclient requirements are installed.
       tags: galaxy
@@ -35,7 +37,7 @@
         requirements: "{{ zhmc_path.stdout }}/ibm/ibm_zhmc/requirements.txt"
         executable: pip3
         extra_args: --upgrade
-      when: env.z.lpar1.create == True or env.z.lpar2.create == True or env.z.lpar3.create == True
+      when: env.z.lpar1.create or env.z.lpar2.create or env.z.lpar3.create
 
     - name: Check to make sure that the KVM host has a corresponding inventory host_vars file named with matching hostname and .yaml extension.
       tags: lpar_check
@@ -43,23 +45,23 @@
         path: "{{ inventory_dir }}/host_vars/{{ env.z.lpar1.hostname }}.yaml"
       when: env.z.lpar1.hostname is defined
       register: lpar_host_vars
-      failed_when: lpar_host_vars.stat.exists == False
+      failed_when: not lpar_host_vars.stat.exists
 
     - name: Check to make sure the second KVM hosts have a corresponding inventory host_vars file named with matching hostname and .yaml extension, if defined.
       tags: lpar_check
       ansible.builtin.stat:
         path: "{{ inventory_dir }}/host_vars/{{ env.z.lpar2.hostname }}.yaml"
-      when: env.z.lpar2.hostname is defined
+      when: env.z.lpar2.hostname is defined and env.z.lpar2.hostname is not none and env.z.lpar2.hostname | length > 0
       register: lpar_host_vars
-      failed_when: lpar_host_vars.stat.exists == False
+      failed_when: not lpar_host_vars.stat.exists
 
     - name: Check to make sure the third KVM hosts have a corresponding inventory host_vars file named with matching hostname and .yaml extension, if defined.
       tags: lpar_check
       ansible.builtin.stat:
         path: "{{ inventory_dir }}/host_vars/{{ env.z.lpar3.hostname }}.yaml"
-      when: env.z.lpar3.hostname is defined
+      when: env.z.lpar3.hostname is defined and env.z.lpar3.hostname is not none and env.z.lpar3.hostname | length > 0
       register: lpar_host_vars
-      failed_when: lpar_host_vars.stat.exists == False
+      failed_when: not lpar_host_vars.stat.exists
 
 - name: "Install packages and cfg ssh"
   hosts: localhost

--- a/playbooks/delete_cluster_nodes.yaml
+++ b/playbooks/delete_cluster_nodes.yaml
@@ -1,0 +1,53 @@
+---
+# This playbook deletes all cluster nodes (bootstrap, control, compute, and infra nodes)
+# based on the configuration in inventories/default/group_vars/all.yaml
+#
+# Usage:
+#   ansible-playbook playbooks/delete_cluster_nodes.yaml
+#
+# To delete nodes from specific KVM hosts only, use tags:
+#   ansible-playbook playbooks/delete_cluster_nodes.yaml --tags kvm_host_1
+#   ansible-playbook playbooks/delete_cluster_nodes.yaml --tags kvm_host_2
+#   ansible-playbook playbooks/delete_cluster_nodes.yaml --tags kvm_host_3
+
+- name: Delete cluster nodes from all KVM hosts
+  hosts: kvm_host
+  tags: always
+  become: true
+  gather_facts: false
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/all.yaml"
+    - "{{ inventory_dir }}/group_vars/secrets.yaml"
+  tasks:
+    - name: Delete cluster nodes on this KVM host
+      ansible.builtin.include_role:
+        name: delete_nodes
+      tags:
+        - kvm_host_1
+        - kvm_host_2
+        - kvm_host_3
+      when: inventory_hostname in groups['kvm_host']
+
+- name: Summary of deleted nodes
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/all.yaml"
+    - "{{ inventory_dir }}/group_vars/secrets.yaml"
+  tasks:
+    - name: Display completion message
+      ansible.builtin.debug:
+        msg:
+          - "=========================================="
+          - "Cluster node deletion completed"
+          - "=========================================="
+          - "All cluster nodes (bootstrap, control, compute, and infra) have been deleted from the configured KVM hosts."
+          - ""
+          - "Note: This playbook does NOT delete:"
+          - "  - The bastion node (use destroy_bastion role if needed)"
+          - "  - Network configurations"
+          - "  - Storage pools"
+          - ""
+          - "To verify, run 'virsh list --all' on each KVM host."
+
+# Made with Bob

--- a/roles/delete_nodes/tasks/main.yaml
+++ b/roles/delete_nodes/tasks/main.yaml
@@ -7,7 +7,7 @@
     virsh destroy "{{ env.cluster.nodes.bootstrap.vm_name }}" || true
     virsh undefine "{{ env.cluster.nodes.bootstrap.vm_name }}" --remove-all-storage --nvram || true
   register: delete_bootstrap
-  when: ( abi.flag is not defined ) or ( abi.flag != True )
+  when: ( abi.flag is not defined ) or ( not abi.flag | bool )
   changed_when: "('destroyed' in delete_bootstrap.stdout) or ('undefined' in delete_bootstrap.stdout)"
 
 - name: Delete control, compute and infra nodes, if exists

--- a/roles/ssh_copy_id/tasks/main.yaml
+++ b/roles/ssh_copy_id/tasks/main.yaml
@@ -21,6 +21,8 @@
     src: ssh-copy-id.exp.j2
     dest: "{{ role_path }}/files/ssh-copy-id-expect-pass.exp"
     force: yes
+  vars:
+    remote_home: "{{ ansible_env.HOME }}"
   delegate_to: 127.0.0.1
 
 - name: Copy expect file to jumphost first, if not running on localhost.
@@ -28,6 +30,7 @@
   ansible.builtin.copy:
     src: "{{ role_path }}/files/ssh-copy-id-expect-pass.exp"
     dest: "~/.ssh/ssh-copy-id-expect-pass.exp"
+  register: ssh_copy
   when: "inventory_hostname != '127.0.0.1'"
 
 - name: Print results of copying ssh id to remote host
@@ -50,7 +53,7 @@
 
 - name: Copy SSH ID from jumphost to remote host with pre-provided password.
   tags: ssh_copy_id, ssh
-  ansible.builtin.command: "expect ~/.ssh/ssh-copy-id-expect-pass.exp"
+  ansible.builtin.shell: "expect {{ ansible_env.HOME }}/.ssh/ssh-copy-id-expect-pass.exp"
   register: ssh_copy
   when: "inventory_hostname != '127.0.0.1'"
 

--- a/roles/ssh_copy_id/templates/ssh-copy-id.exp.j2
+++ b/roles/ssh_copy_id/templates/ssh-copy-id.exp.j2
@@ -10,7 +10,7 @@ if {$force_conservative} {
 }
 
 set timeout 20
-spawn ssh-copy-id -f -o StrictHostKeyChecking=no -i {{ ssh_target[3] }} {{ ssh_target[1] }}@{{ ssh_target[0] }}
+spawn ssh-copy-id -f -o StrictHostKeyChecking=no -i {{ ssh_target[3] | regex_replace('^~', remote_home) }} {{ ssh_target[1] }}@{{ ssh_target[0] }}
 expect {
 	"password: " {
 		send -- "{{ ssh_target[2] }}\r"


### PR DESCRIPTION
This PR adds the missing feature to tear down the cluster. It doesn't tear down the bastion or remove the entries from dns or haproxy.
This supports only the UPI on KVM use case.
In addition we need to untrack the hosts file to prevent furture issue with the default hosts file.

AI involved: yes.