### PR TITLE
fix: Modify the access to bastion for NAT.

### DIFF
--- a/roles/set_inventory/templates/hosts.j2
+++ b/roles/set_inventory/templates/hosts.j2
@@ -23,7 +23,7 @@
 {% endif %}
 
 [bastion]
-{{ env.bastion.networking.hostname }} ansible_host={{ env.bastion.networking.ip }} ansible_user={{ env.bastion.access.user }} ansible_become_password='{{ '{{' }} env.bastion.access.pass {{ '}}' }}'
+{{ env.bastion.networking.hostname }} ansible_host={{ env.bastion.networking.ip }} ansible_user={{ env.bastion.access.user }} ansible_become_password='{{ '{{' }} env.bastion.access.pass {{ '}}' }}'{% if ( env.network_mode | upper == 'NAT' ) and ( env.jumphost.ip is not none ) %} ansible_ssh_common_args='-o StrictHostKeyChecking=no -o ProxyJump="{{ env.jumphost.user }}@{{ env.jumphost.ip }}"'{% endif %}
 
 {% if ( env.network_mode | upper == 'NAT' ) and ( env.jumphost.name is not none ) and ( env.jumphost.ip is not none ) and ( env.jumphost.user is not none ) and ( env.jumphost.pass is not none ) -%}
 {{ '[jumphost]' }}

--- a/roles/ssh_add_config/tasks/main.yaml
+++ b/roles/ssh_add_config/tasks/main.yaml
@@ -1,5 +1,21 @@
 ---
 
+- name: Ensure ~/.ssh directory exists
+  tags: ssh_copy_id, ssh
+  ansible.builtin.file:
+    path: ~/.ssh
+    state: directory
+    mode: '0700'
+
+- name: Ensure ~/.ssh/config file exists
+  tags: ssh_copy_id, ssh
+  ansible.builtin.file:
+    path: ~/.ssh/config
+    state: touch
+    mode: '0600'
+    modification_time: preserve
+    access_time: preserve
+
 - name: Create ssh config file (or add to an exsting file) to if network mode is NAT
   tags: ssh_copy_id, ssh
   ansible.builtin.blockinfile:
@@ -8,12 +24,12 @@
     create: true
     mode: '0644'
     block: |
-      Host {{ env.jumphost.name }} 
+      Host {{ env.jumphost.name }}
         HostName {{ env.jumphost.ip }}
         User {{ env.jumphost.user }}
         IdentityFile {{ path_to_key_pair.split('.')[:-1] | join('.') }}
       Host {{ env.bastion.networking.ip }}
-        HostName {{ env.bastion.networking.ip }} 
+        HostName {{ env.bastion.networking.ip }}
         User {{ env.bastion.access.user }}
         IdentityFile {{ path_to_key_pair.split('.')[:-1] | join('.') }}
-        ProxyJump {{ env.jumphost.name }} 
+        ProxyJump {{ env.jumphost.name }}


### PR DESCRIPTION
name: Pull request
about: Describe the proposed change
AI involved: yes

Describe the change
This pull request updates the hosts.j2 inventory template to automatically configure SSH proxy jump settings for the bastion host when the environment is configured in NAT network mode with a jumphost defined.

Specifically, the change appends ansible_ssh_common_args with -o StrictHostKeyChecking=no -o ProxyJump="@" to the bastion host entry in the generated inventory file, but only when both of the following conditions are met:

-    The network_mode is set to NAT
-    A valid jumphost.ip is defined (not none)
-    Two new tasks prepended — ensure ~/.ssh/ exists with mode 0700 and that ~/.ssh/config exists as an empty file with mode 0600 before anything tries to use it. modification_time: preserve / access_time: preserve means the touch is a no-op if the file already exists, so it is fully idempotent.
 
Previously, SSH connections to the bastion in NAT mode required manual SSH configuration to route traffic through the jumphost. This change ensures the proxy jump configuration is automatically included in the generated Ansible inventory, allowing Ansible to correctly route connections to the bastion through the jumphost without additional manual setup.

Testing

-    Tested by generating an inventory file in a NAT network mode environment with a configured jumphost, verifying that the ansible_ssh_common_args attribute is correctly appended to the bastion host entry.
-    Verified that in non-NAT environments or when jumphost.ip is none, the bastion host entry is generated without the ansible_ssh_common_args attribute, confirming no regression in existing behavior.
