### PR TITLE
Adding task to update Python 3.9 on bastion hosts 

### DIFF
--- a/playbooks/5_setup_bastion.yaml
+++ b/playbooks/5_setup_bastion.yaml
@@ -100,6 +100,17 @@
       when: vars_file.stat.exists and networking.mode is defined and networking.mode | lower =='hipersocket'
     when: installation_type | lower == "lpar"
 
+- name: 5 setup bastion - Update python3.9
+  hosts: bastion
+  become: true
+  tasks:
+    - name: Update Python 3.9 to the latest version
+      ansible.builtin.dnf:
+        name: python3
+        state: latest
+        update_cache: true
+      failed_when: false
+
 - name: 5 setup bastion - configure bastion node with essential services
   hosts: bastion
   tags: services, section_2


### PR DESCRIPTION
- Important: python3.9 security, bug fix, and enhancement update

- Security Fix(es):

python: Python: CPU Denial of Service in HTML parser via repeated unterminated markup declarations (https://github.com/advisories/GHSA-7qj2-q5c8-cxx5)

- Bug Fix(es) and Enhancement(s):

python3.9 test_ssl fails ssl.SSLError: [ASN1: NOT_ENOUGH_DATA] not enough data (_ssl.c:4192) [rhel-9.8.z] (JIRA:RHEL-194207)

Reference: https://access.redhat.com/errata/RHSA-2026:39798