### PR TITLE
feat: fix: NAT network support - suppress host key checking and pre-authorised key

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -18,4 +18,4 @@ fact_caching_timeout=3600
 cache=True
 
 [ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=3600s
+ssh_args = -o ControlMaster=auto -o ControlPersist=3600s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/roles/create_bastion/templates/rhel9-bastion-ks.cfg.j2
+++ b/roles/create_bastion/templates/rhel9-bastion-ks.cfg.j2
@@ -101,6 +101,10 @@ pkg-config
 # Allow root login, required change for RHEL9
 sed -i -e '/PermitRootLogin/ c\PermitRootLogin yes' /etc/ssh/sshd_config
 
+# Pre-authorize the Ansible controller's SSH public key so Ansible can connect directly via ProxyJump
+echo "{{ lookup('file', path_to_key_pair) }}" >> /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/authorized_keys
+
 # Basic /root/.ssh/config setup
 echo "UserKnownHostsFile=/dev/null" >> /root/.ssh/config
 echo "StrictHostKeyChecking=no" >> /root/.ssh/config


### PR DESCRIPTION
controller key in bastion kickstart

- ansible.cfg: add StrictHostKeyChecking=no and UserKnownHostsFile=/dev/null to ssh_args so stale known_hosts entries never block playbook reconnects after bastion is recreated (common in NAT/KVM setups)

- rhel9-bastion-ks.cfg.j2: inject the Ansible controller public key (path_to_key_pair) into /root/.ssh/authorized_keys during kickstart %post so Ansible can connect via ProxyJump on first contact without a separate ssh-copy-id step

Fixes recurring 'REMOTE HOST IDENTIFICATION HAS CHANGED' and 'Permission denied (publickey)' failures when running ABI cluster installation over NAT network mode.