### PR TITLE
fix: Add more wait time for slower envs.

### DIFF
--- a/roles/create_bootstrap/defaults/main.yaml
+++ b/roles/create_bootstrap/defaults/main.yaml
@@ -7,3 +7,6 @@ rhcos_os_variant: rhl9
 rhcos_live_kernel: "rhcos-live-kernel.s390x"
 rhcos_live_initrd: "rhcos-live-initramfs.s390x.img"
 rhcos_live_rootfs: "rhcos-live-rootfs.s390x.img"
+
+# Timeout in seconds for node creation via virt-install
+timeout_node_creation: 420

--- a/roles/create_bootstrap/tasks/main.yaml
+++ b/roles/create_bootstrap/tasks/main.yaml
@@ -33,7 +33,7 @@
     --console pty,target_type=serial \
     --wait=-1 \
     --noautoconsole
-  timeout: 480
+  timeout: "{{ timeout_node_creation }}"
   register: cmd_output
 
 - name: Debug, print above command output

--- a/roles/wait_for_bootstrap/tasks/main.yaml
+++ b/roles/wait_for_bootstrap/tasks/main.yaml
@@ -19,8 +19,8 @@ SSH to root@bastion, SSH to core@bootstrap-ip and run 'journalctl -b -f -u relea
 - name: Start openshift-installer with 'wait-for bootstrap-complete' (async task)
   tags: wait_for_bootstrap
   ansible.builtin.command: openshift-install wait-for bootstrap-complete --dir=/root/ocpinst
-  # Installer will wait up to ~50 min
-  async: 3060
+  # Installer will wait up to 60 min
+  async: 3600
   poll: 0
   register: watch_bootstrap
 
@@ -31,9 +31,9 @@ SSH to bastion, switch to root, from there, SSH to core@bootstrap-ip and run 'jo
     jid: "{{ watch_bootstrap.ansible_job_id }}"
   register: bootstrapping
   until: bootstrapping.finished
-  # Set wait time to 60 min, because it depends highly on system performance and network speed
+  # Set wait time to 90 min, because it depends highly on system performance and network speed
   retries: 120
-  delay: 30
+  delay: 45
 
 - name: Make sure kubeconfig works properly
   tags: wait_for_bootstrap


### PR DESCRIPTION
Fix for https://github.com/IBM/Ansible-OpenShift-Provisioning/issues/546
The wait time for bootstrapping need to be extended, too. On slower environments the scripts might fail because the overall processing time is slow and the operators do not progressing in a timely manner.
Make the wait time for creating the bootstrap configurable (the same parameter used like the other nodes) and prolong the wait time for the bootstrap process in general.
Tested with two different KVM LPARs (NAT).
 
AI involved: no